### PR TITLE
fix: transaction error type

### DIFF
--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",

--- a/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
@@ -61,7 +61,7 @@ const parseEvent = (event: TransactionEvent) => {
         : null,
     error:
       event.name === INTERACTION_TYPE.TRANSACTION_FAILED
-        ? event.data.error
+        ? event.data.error.Message
         : undefined,
   }
 }

--- a/libs/wallet-ui/src/types/interaction.ts
+++ b/libs/wallet-ui/src/types/interaction.ts
@@ -72,7 +72,9 @@ export interface RequestTransactionSuccessContent {
 export interface RequestTransactionFailureContent {
   tx: string
   deserializedInputData: string
-  error: string
+  error: {
+    Message: string
+  }
   sentAt: string
 }
 


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/471

# Description ℹ️

When a transaction fails, can't be opened again because of an incorrect / outdated error type.
