### PR TITLE
fix: allow app window to drag when modal open

### DIFF
--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",

--- a/libs/wallet-ui/src/components/dialog/dialog.tsx
+++ b/libs/wallet-ui/src/components/dialog/dialog.tsx
@@ -36,7 +36,14 @@ export function Dialog({
                 <DialogPrimitives.Overlay forceMount={true} asChild={true}>
                   <animated.div
                     className="fixed top-0 right-0 bottom-0 left-0 h-full bg-overlay"
-                    style={{ opacity: styles.opacity }}
+                    style={{
+                      // The app is frameless by default so this element creates a space at the top of the app
+                      // which you can click and drag to move the app around.
+                      // https://wails.io/docs/guides/frameless/
+                      // @ts-ignore: Allow custom css property for wails
+                      '--wails-draggable': 'drag',
+                      opacity: styles.opacity,
+                    }}
                     data-wails-drag
                   />
                 </DialogPrimitives.Overlay>


### PR DESCRIPTION
# Related issues 🔗

Closes #63 

# Description ℹ️

Add `'--wails-draggable': 'drag'` to the modal backdrop so the OS knows it can be dragged. When there is a modal open, the backdrop covers the top app bar, which is the draggable item in the ui. 