### PR TITLE
chore: remove interaction enums

### DIFF
--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.1.34",
+  "version": "0.1.36",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",

--- a/libs/wallet-ui/src/components/interaction-manager/content/passphrase.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/passphrase.tsx
@@ -9,11 +9,7 @@ import type {
   InteractionContentProps,
   RequestPassphrase,
 } from '../../../types/interaction'
-import {
-  EVENT_FLOW_TYPE,
-  INTERACTION_RESPONSE_TYPE,
-  INTERACTION_TYPE,
-} from '../../../types/interaction'
+import { EVENT_FLOW_TYPE } from '../../../types/interaction'
 
 export const Passphrase = ({
   event,

--- a/libs/wallet-ui/src/components/interaction-manager/content/passphrase.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/passphrase.tsx
@@ -33,7 +33,7 @@ export const Passphrase = ({
         // @ts-ignore: wails generates the wrong type signature for this handler
         await service.RespondToInteraction({
           traceID: event.traceID,
-          name: INTERACTION_RESPONSE_TYPE.ENTERED_PASSPHRASE,
+          name: 'ENTERED_PASSPHRASE',
           data: {
             passphrase,
           },
@@ -42,14 +42,10 @@ export const Passphrase = ({
         if (flow === EVENT_FLOW_TYPE.PERMISSION_REQUEST) {
           const source = history.find(
             (interaction) =>
-              interaction.event.name ===
-              INTERACTION_TYPE.REQUEST_PERMISSIONS_REVIEW
+              interaction.event.name === 'REQUEST_PERMISSIONS_REVIEW'
           )
 
-          if (
-            source &&
-            source.event.name === INTERACTION_TYPE.REQUEST_PERMISSIONS_REVIEW
-          ) {
+          if (source && source.event.name === 'REQUEST_PERMISSIONS_REVIEW') {
             const { wallet, hostname } = source?.event.data || {}
 
             const { permissions } = await client.DescribePermissions({
@@ -73,7 +69,7 @@ export const Passphrase = ({
         if (err === 'dismissed') {
           await service.RespondToInteraction({
             traceID: event.traceID,
-            name: INTERACTION_RESPONSE_TYPE.CANCEL_REQUEST,
+            name: 'CANCEL_REQUEST',
           })
         } else {
           AppToaster.show({

--- a/libs/wallet-ui/src/components/interaction-manager/content/permissions.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/permissions.tsx
@@ -12,14 +12,16 @@ import type {
   InteractionContentProps,
   RequestPermissions,
   RequestPermissionsContent,
+  PermissionTargetType,
+  PermissionTypes,
 } from '../../../types/interaction'
 import { PermissionTarget, PermissionType } from '../../../types/interaction'
 import { INTERACTION_RESPONSE_TYPE } from '../../../types/interaction'
 
 const getPermissionAction = (
   data: RequestPermissionsContent,
-  target: PermissionTarget,
-  type: PermissionType
+  target: PermissionTargetType,
+  type: PermissionTypes
 ) => {
   switch (`${type}:${target}`) {
     case `${PermissionType.READ}:${PermissionTarget.PUBLIC_KEYS}`: {
@@ -32,7 +34,7 @@ const getPermissionAction = (
 }
 
 const getDisplayDetails = (data: RequestPermissionsContent) => {
-  const targets = Object.keys(data.permissions) as PermissionTarget[]
+  const targets = Object.keys(data.permissions) as PermissionTargetType[]
   const requestText = (
     <>
       <strong>{data.hostname}</strong> is requesting

--- a/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
@@ -10,7 +10,6 @@ import type {
   RequestTransactionReview,
   RequestTransactionSuccess,
 } from '../../../types/interaction'
-import { INTERACTION_TYPE } from '../../../types/interaction'
 
 type TransactionEndProps =
   | InteractionContentProps<RequestTransactionSuccess>

--- a/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
@@ -47,7 +47,7 @@ const parseTx = (tx: string) => {
 }
 
 const parseEvent = (event: TransactionEvent) => {
-  const isSuccess = event.name === INTERACTION_TYPE.TRANSACTION_SUCCEEDED
+  const isSuccess = event.name === 'TRANSACTION_SUCCEEDED'
   const txData = parseTx(event.data.tx)
   const inputData = parseInputData(event.data.deserializedInputData)
 
@@ -55,12 +55,9 @@ const parseEvent = (event: TransactionEvent) => {
     ...txData,
     ...inputData,
     status: isSuccess ? TransactionStatus.SUCCESS : TransactionStatus.FAILURE,
-    txHash:
-      event.name === INTERACTION_TYPE.TRANSACTION_SUCCEEDED
-        ? event.data.txHash
-        : null,
+    txHash: event.name === 'TRANSACTION_SUCCEEDED' ? event.data.txHash : null,
     error:
-      event.name === INTERACTION_TYPE.TRANSACTION_FAILED
+      event.name === 'TRANSACTION_FAILED'
         ? event.data.error.Message
         : undefined,
   }
@@ -91,8 +88,7 @@ export const TransactionEnd = ({
   const source = useMemo(
     () =>
       history.find(
-        ({ event }) =>
-          event.name === INTERACTION_TYPE.REQUEST_TRANSACTION_REVIEW_FOR_SENDING
+        ({ event }) => event.name === 'REQUEST_TRANSACTION_REVIEW_FOR_SENDING'
       ) as Interaction<RequestTransactionReview> | null,
     [history]
   )

--- a/libs/wallet-ui/src/components/interaction-manager/content/transaction.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/transaction.tsx
@@ -14,7 +14,6 @@ import type {
   InteractionContentProps,
   RequestTransactionReview,
 } from '../../../types/interaction'
-import { INTERACTION_RESPONSE_TYPE } from '../../../types/interaction'
 
 export const TRANSACTION_TITLES: Record<TransactionKeys, string> = {
   [TransactionKeys.UNKNOWN]: 'Unknown transaction',

--- a/libs/wallet-ui/src/components/interaction-manager/content/transaction.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/transaction.tsx
@@ -92,7 +92,7 @@ export const Transaction = ({
 
       await service.RespondToInteraction({
         traceID: event.traceID,
-        name: INTERACTION_RESPONSE_TYPE.DECISION,
+        name: 'DECISION',
         data: {
           approved: decision,
         },

--- a/libs/wallet-ui/src/components/interaction-manager/content/wallet-connection.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/wallet-connection.tsx
@@ -8,10 +8,7 @@ import type {
   InteractionContentProps,
   RequestWalletConnection,
 } from '../../../types/interaction'
-import {
-  CONNECTION_RESPONSE,
-  INTERACTION_RESPONSE_TYPE,
-} from '../../../types/interaction'
+import { CONNECTION_RESPONSE } from '../../../types/interaction'
 
 export const WalletConnection = ({
   event,

--- a/libs/wallet-ui/src/components/interaction-manager/content/wallet-connection.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/wallet-connection.tsx
@@ -26,7 +26,7 @@ export const WalletConnection = ({
       try {
         await service.RespondToInteraction({
           traceID: event.traceID,
-          name: INTERACTION_RESPONSE_TYPE.WALLET_CONNECTION_DECISION,
+          name: 'WALLET_CONNECTION_DECISION',
           data: {
             connectionApproval: decision
               ? CONNECTION_RESPONSE.APPROVED_ONCE

--- a/libs/wallet-ui/src/components/interaction-manager/content/wallet-selection.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/wallet-selection.tsx
@@ -48,7 +48,7 @@ export const WalletSelection = ({
       try {
         await service.RespondToInteraction({
           traceID: event.traceID,
-          name: INTERACTION_RESPONSE_TYPE.SELECTED_WALLET,
+          name: 'SELECTED_WALLET',
           data: {
             wallet,
             passphrase,

--- a/libs/wallet-ui/src/components/interaction-manager/interaction-flow.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/interaction-flow.tsx
@@ -11,6 +11,7 @@ import { TransactionEnd } from './content/transaction-end'
 import { WalletConnection } from './content/wallet-connection'
 import { WalletSelection } from './content/wallet-selection'
 import type {
+  EventFlowType,
   Interaction,
   InteractionContentProps,
   RawInteraction,
@@ -29,7 +30,7 @@ const InteractionItem = ({
   const [isResolved, setResolved] = useState(false)
 
   switch (event.name) {
-    case INTERACTION_TYPE.REQUEST_WALLET_CONNECTION_REVIEW: {
+    case 'REQUEST_WALLET_CONNECTION_REVIEW': {
       return (
         <WalletConnection
           event={event}
@@ -41,7 +42,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.REQUEST_WALLET_SELECTION: {
+    case 'REQUEST_WALLET_SELECTION': {
       return (
         <WalletSelection
           event={event}
@@ -53,7 +54,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.REQUEST_PERMISSIONS_REVIEW: {
+    case 'REQUEST_PERMISSIONS_REVIEW': {
       return (
         <Permissions
           event={event}
@@ -65,7 +66,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.REQUEST_TRANSACTION_REVIEW_FOR_SENDING: {
+    case 'REQUEST_TRANSACTION_REVIEW_FOR_SENDING': {
       return (
         <Transaction
           event={event}
@@ -77,7 +78,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.TRANSACTION_SUCCEEDED: {
+    case 'TRANSACTION_SUCCEEDED': {
       return (
         <TransactionEnd
           event={event}
@@ -89,7 +90,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.TRANSACTION_FAILED: {
+    case 'TRANSACTION_FAILED': {
       return (
         <TransactionEnd
           event={event}
@@ -101,7 +102,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.REQUEST_PASSPHRASE: {
+    case 'REQUEST_PASSPHRASE': {
       return (
         <Passphrase
           event={event}
@@ -113,7 +114,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.REQUEST_SUCCEEDED: {
+    case 'REQUEST_SUCCEEDED': {
       return (
         <SuccessComponent
           event={event}
@@ -125,7 +126,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.ERROR_OCCURRED: {
+    case 'ERROR_OCCURRED': {
       return (
         <ErrorComponent
           event={event}
@@ -137,7 +138,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.LOG: {
+    case 'LOG': {
       return (
         <LogComponent
           event={event}
@@ -149,7 +150,7 @@ const InteractionItem = ({
         />
       )
     }
-    case INTERACTION_TYPE.INTERACTION_SESSION_ENDED: {
+    case 'INTERACTION_SESSION_ENDED': {
       return (
         <SessionEndComponent
           event={event}
@@ -168,7 +169,7 @@ const InteractionItem = ({
 }
 
 const getEventFlowType = (events: Interaction[]) => {
-  return events.reduce<EVENT_FLOW_TYPE | undefined>((acc, interaction) => {
+  return events.reduce<EventFlowType | undefined>((acc, interaction) => {
     switch (interaction.event.name) {
       case INTERACTION_TYPE.REQUEST_WALLET_CONNECTION_REVIEW: {
         return acc || EVENT_FLOW_TYPE.WALLET_CONNECTION

--- a/libs/wallet-ui/src/index.tsx
+++ b/libs/wallet-ui/src/index.tsx
@@ -19,6 +19,8 @@ import type { Runtime } from './types/runtime'
 import type { Features } from './types/features'
 export { FeatureMap } from './types/features'
 
+export * from './types'
+
 export type AppProps = {
   service: Service
   client: WalletAdmin

--- a/libs/wallet-ui/src/types/interaction.ts
+++ b/libs/wallet-ui/src/types/interaction.ts
@@ -1,15 +1,20 @@
 import type { Dispatch, SetStateAction } from 'react'
 
-export const enum EVENT_FLOW_TYPE {
-  WALLET_CONNECTION = 'WALLET_CONNECTION',
-  TRANSACTION_REVIEW = 'TRANSACTION_REVIEW',
-  PERMISSION_REQUEST = 'PERMISSION_REQUEST',
+export type EventFlowType =
+  | 'WALLET_CONNECTION'
+  | 'TRANSACTION_REVIEW'
+  | 'PERMISSION_REQUEST'
+
+export const EVENT_FLOW_TYPE: Record<EventFlowType, EventFlowType> = {
+  WALLET_CONNECTION: 'WALLET_CONNECTION',
+  TRANSACTION_REVIEW: 'TRANSACTION_REVIEW',
+  PERMISSION_REQUEST: 'PERMISSION_REQUEST',
 }
 
 export type InteractionContentProps<T extends RawInteraction> = {
   event: T
   history: Interaction[]
-  flow?: EVENT_FLOW_TYPE
+  flow?: EventFlowType
   isResolved: boolean
   setResolved: Dispatch<SetStateAction<boolean>>
   onFinish: () => void
@@ -40,18 +45,22 @@ export interface RequestPassphraseContent {
   wallet: string
 }
 
-export const enum PermissionTarget {
-  PUBLIC_KEYS = 'public_keys',
+export type PermissionTargetType = 'public_keys'
+
+export const PermissionTarget: Record<'PUBLIC_KEYS', PermissionTargetType> = {
+  PUBLIC_KEYS: 'public_keys',
 }
 
-export const enum PermissionType {
-  READ = 'read',
+export type PermissionTypes = 'read'
+
+export const PermissionType: Record<'READ', PermissionTypes> = {
+  READ: 'read',
 }
 
 export interface RequestPermissionsContent {
   hostname: string
   wallet: string
-  permissions: Record<PermissionTarget, PermissionType>
+  permissions: Record<PermissionTargetType, PermissionTypes>
 }
 
 export interface RequestTransactionReviewContent {
@@ -92,89 +101,104 @@ export interface RequestSucceededContent {
 
 // Received interaction events
 
-export const enum INTERACTION_TYPE {
-  INTERACTION_SESSION_BEGAN = 'INTERACTION_SESSION_BEGAN',
-  INTERACTION_SESSION_ENDED = 'INTERACTION_SESSION_ENDED',
-  REQUEST_WALLET_CONNECTION_REVIEW = 'REQUEST_WALLET_CONNECTION_REVIEW',
-  REQUEST_WALLET_SELECTION = 'REQUEST_WALLET_SELECTION',
-  REQUEST_PERMISSIONS_REVIEW = 'REQUEST_PERMISSIONS_REVIEW',
-  REQUEST_TRANSACTION_REVIEW_FOR_SENDING = 'REQUEST_TRANSACTION_REVIEW_FOR_SENDING',
-  TRANSACTION_SUCCEEDED = 'TRANSACTION_SUCCEEDED',
-  TRANSACTION_FAILED = 'TRANSACTION_FAILED',
-  REQUEST_PASSPHRASE = 'REQUEST_PASSPHRASE',
-  REQUEST_SUCCEEDED = 'REQUEST_SUCCEEDED',
-  ERROR_OCCURRED = 'ERROR_OCCURRED',
-  LOG = 'LOG',
+export type InteractionType =
+  | 'INTERACTION_SESSION_BEGAN'
+  | 'INTERACTION_SESSION_ENDED'
+  | 'REQUEST_WALLET_CONNECTION_REVIEW'
+  | 'REQUEST_WALLET_SELECTION'
+  | 'REQUEST_PERMISSIONS_REVIEW'
+  | 'REQUEST_TRANSACTION_REVIEW_FOR_SENDING'
+  | 'TRANSACTION_SUCCEEDED'
+  | 'TRANSACTION_FAILED'
+  | 'REQUEST_PASSPHRASE'
+  | 'REQUEST_SUCCEEDED'
+  | 'ERROR_OCCURRED'
+  | 'LOG'
+
+export const INTERACTION_TYPE: Record<InteractionType, InteractionType> = {
+  INTERACTION_SESSION_BEGAN: 'INTERACTION_SESSION_BEGAN',
+  INTERACTION_SESSION_ENDED: 'INTERACTION_SESSION_ENDED',
+  REQUEST_WALLET_CONNECTION_REVIEW: 'REQUEST_WALLET_CONNECTION_REVIEW',
+  REQUEST_WALLET_SELECTION: 'REQUEST_WALLET_SELECTION',
+  REQUEST_PERMISSIONS_REVIEW: 'REQUEST_PERMISSIONS_REVIEW',
+  REQUEST_TRANSACTION_REVIEW_FOR_SENDING:
+    'REQUEST_TRANSACTION_REVIEW_FOR_SENDING',
+  TRANSACTION_SUCCEEDED: 'TRANSACTION_SUCCEEDED',
+  TRANSACTION_FAILED: 'TRANSACTION_FAILED',
+  REQUEST_PASSPHRASE: 'REQUEST_PASSPHRASE',
+  REQUEST_SUCCEEDED: 'REQUEST_SUCCEEDED',
+  ERROR_OCCURRED: 'ERROR_OCCURRED',
+  LOG: 'LOG',
 }
 
 export type RequestWalletConnection = {
   traceID: string
-  name: INTERACTION_TYPE.REQUEST_WALLET_CONNECTION_REVIEW
+  name: 'REQUEST_WALLET_CONNECTION_REVIEW'
   data: RequestWalletConnectionContent
 }
 
 export type RequestWalletSelection = {
   traceID: string
-  name: INTERACTION_TYPE.REQUEST_WALLET_SELECTION
+  name: 'REQUEST_WALLET_SELECTION'
   data: RequestWalletSelectionContent
 }
 
 export type RequestPermissions = {
   traceID: string
-  name: INTERACTION_TYPE.REQUEST_PERMISSIONS_REVIEW
+  name: 'REQUEST_PERMISSIONS_REVIEW'
   data: RequestPermissionsContent
 }
 
 export type RequestTransactionReview = {
   traceID: string
-  name: INTERACTION_TYPE.REQUEST_TRANSACTION_REVIEW_FOR_SENDING
+  name: 'REQUEST_TRANSACTION_REVIEW_FOR_SENDING'
   data: RequestTransactionReviewContent
 }
 
 export type RequestTransactionSuccess = {
   traceID: string
-  name: INTERACTION_TYPE.TRANSACTION_SUCCEEDED
+  name: 'TRANSACTION_SUCCEEDED'
   data: RequestTransactionSuccessContent
 }
 
 export type RequestTransactionFailure = {
   traceID: string
-  name: INTERACTION_TYPE.TRANSACTION_FAILED
+  name: 'TRANSACTION_FAILED'
   data: RequestTransactionFailureContent
 }
 
 export type RequestPassphrase = {
   traceID: string
-  name: INTERACTION_TYPE.REQUEST_PASSPHRASE
+  name: 'REQUEST_PASSPHRASE'
   data: RequestPassphraseContent
 }
 
 export type RequestSucceeded = {
   traceID: string
-  name: INTERACTION_TYPE.REQUEST_SUCCEEDED
+  name: 'REQUEST_SUCCEEDED'
   data: RequestSucceededContent
 }
 
 export type ErrorOccurred = {
   traceID: string
-  name: INTERACTION_TYPE.ERROR_OCCURRED
+  name: 'ERROR_OCCURRED'
   data: ErrorOccurredContent
 }
 
 export type Log = {
   traceID: string
-  name: INTERACTION_TYPE.LOG
+  name: 'LOG'
   data: LogContent
 }
 
 export type SessionStarted = {
   traceID: string
-  name: INTERACTION_TYPE.INTERACTION_SESSION_BEGAN
+  name: 'INTERACTION_SESSION_BEGAN'
 }
 
 export type SessionEnded = {
   traceID: string
-  name: INTERACTION_TYPE.INTERACTION_SESSION_ENDED
+  name: 'INTERACTION_SESSION_ENDED'
 }
 
 export type RawInteraction =
@@ -200,12 +224,22 @@ export type Interaction<T extends RawInteraction = RawInteraction> = {
 
 // Responses
 
-export const enum INTERACTION_RESPONSE_TYPE {
-  CANCEL_REQUEST = 'CANCEL_REQUEST',
-  DECISION = 'DECISION',
-  ENTERED_PASSPHRASE = 'ENTERED_PASSPHRASE',
-  WALLET_CONNECTION_DECISION = 'WALLET_CONNECTION_DECISION',
-  SELECTED_WALLET = 'SELECTED_WALLET',
+export type InteractionResponseType =
+  | 'CANCEL_REQUEST'
+  | 'DECISION'
+  | 'ENTERED_PASSPHRASE'
+  | 'WALLET_CONNECTION_DECISION'
+  | 'SELECTED_WALLET'
+
+export const INTERACTION_RESPONSE_TYPE: Record<
+  InteractionResponseType,
+  InteractionResponseType
+> = {
+  CANCEL_REQUEST: 'CANCEL_REQUEST',
+  DECISION: 'DECISION',
+  ENTERED_PASSPHRASE: 'ENTERED_PASSPHRASE',
+  WALLET_CONNECTION_DECISION: 'WALLET_CONNECTION_DECISION',
+  SELECTED_WALLET: 'SELECTED_WALLET',
 }
 
 // response data types
@@ -214,12 +248,21 @@ export interface EnteredPassphrase {
   passphrase: string
 }
 
-export const enum CONNECTION_RESPONSE {
-  APPROVED_ONCE = 'APPROVED_ONLY_THIS_TIME',
-  REJECTED_ONCE = 'REJECTED_ONLY_THIS_TIME',
+export type ConnectionResponseKeyType = 'APPROVED_ONCE' | 'REJECTED_ONCE'
+
+export type ConnectionResponseType =
+  | 'APPROVED_ONLY_THIS_TIME'
+  | 'REJECTED_ONLY_THIS_TIME'
+
+export const CONNECTION_RESPONSE: Record<
+  ConnectionResponseKeyType,
+  ConnectionResponseType
+> = {
+  APPROVED_ONCE: 'APPROVED_ONLY_THIS_TIME',
+  REJECTED_ONCE: 'REJECTED_ONLY_THIS_TIME',
 }
 export interface WalletConnectionDecision {
-  connectionApproval: CONNECTION_RESPONSE
+  connectionApproval: ConnectionResponseType
 }
 
 export interface SelectedWallet {
@@ -235,31 +278,31 @@ export interface Decision {
 
 export type InteractionResponseEnteredPassphrase = {
   traceID: string
-  name: INTERACTION_RESPONSE_TYPE.ENTERED_PASSPHRASE
+  name: 'ENTERED_PASSPHRASE'
   data: EnteredPassphrase
 }
 
 export type InteractionResponseWalletConnectionDecision = {
   traceID: string
-  name: INTERACTION_RESPONSE_TYPE.WALLET_CONNECTION_DECISION
+  name: 'WALLET_CONNECTION_DECISION'
   data: WalletConnectionDecision
 }
 
 export type InteractionResponseSelectedWallet = {
   traceID: string
-  name: INTERACTION_RESPONSE_TYPE.SELECTED_WALLET
+  name: 'SELECTED_WALLET'
   data: SelectedWallet
 }
 
 export type InteractionResponseDecision = {
   traceID: string
-  name: INTERACTION_RESPONSE_TYPE.DECISION
+  name: 'DECISION'
   data: Decision
 }
 
 export type InteractionResponseCancelEvent = {
   traceID: string
-  name: INTERACTION_RESPONSE_TYPE.CANCEL_REQUEST
+  name: 'CANCEL_REQUEST'
 }
 
 export type InteractionResponse =


### PR DESCRIPTION
# Related issues 🔗

Closes n/a

# Description ℹ️

Remove enums from interaction types so they can be used outside the library. Currently the enums are being present only in the type definitions (`*.d.ts` files), and they can't be used in runtimes (e.g. as object keys, etc) outside the wallet-ui monorepo
