### PR TITLE
fix: network compatibility message when network info is missing

### DIFF
--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",

--- a/libs/wallet-ui/src/components/network-compatibility-dialog/network-compatibility-dialog.tsx
+++ b/libs/wallet-ui/src/components/network-compatibility-dialog/network-compatibility-dialog.tsx
@@ -205,14 +205,16 @@ export const NetworkCompatibilityDialog = () => {
             </p>
           )}
           <ButtonGroup inline className="py-[20px]">
-            <AnchorButton
-              data-testid="network-compatibility-release"
-              href="https://github.com/vegaprotocol/vegawallet-desktop/releases"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Get a compatible release
-            </AnchorButton>
+            {!networkData.network && (
+              <AnchorButton
+                data-testid="network-compatibility-release"
+                href="https://github.com/vegaprotocol/vegawallet-desktop/releases"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Get a compatible release
+              </AnchorButton>
+            )}
             {compatibleNetworksList.length > 0 && (
               <Button
                 data-testid="network-compatibility-change"

--- a/libs/wallet-ui/src/components/network-compatibility-dialog/network-compatibility-dialog.tsx
+++ b/libs/wallet-ui/src/components/network-compatibility-dialog/network-compatibility-dialog.tsx
@@ -179,12 +179,20 @@ export const NetworkCompatibilityDialog = () => {
     >
       {subview === null && (
         <div className="p-[20px]">
-          <p className="mb-[20px]">
-            Your selected network "<code>{networkData.network}</code>" is
-            running on Vega <code>{networkData.retrievedVersion}</code>, however
-            this app only supports networks running{' '}
-            <code>{supportedVersion}</code>.
-          </p>
+          {!networkData.network && (
+            <p className="mb-[20px]">
+              Couldn't retrieve the network compatibility information from the
+              nodes you are trying to connect to.
+            </p>
+          )}
+          {networkData.network && (
+            <p className="mb-[20px]">
+              Your selected network "<code>{networkData.network}</code>" is
+              running on Vega <code>{networkData.retrievedVersion}</code>,
+              however this app only supports networks running{' '}
+              <code>{supportedVersion}</code>.
+            </p>
+          )}
           {compatibleNetworksList.length > 0 && (
             <p className="mb-[20px]">
               Download a compatible release or change network to continue.


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/497

# Description ℹ️

When network compatibility info is missing from a network, display an alternative message as described in the ticket.
