### PR TITLE
feat: add transaction log to details view

### DIFF
--- a/libs/wallet-theme/src/config.js
+++ b/libs/wallet-theme/src/config.js
@@ -62,6 +62,7 @@ module.exports = {
     },
     neutral: {
       DEFAULT: '#6E6E6E',
+      light: '#A7A7A7',
     },
     emphasise: '#F5F8fA',
     deemphasise: '#8A9BA8',

--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",

--- a/libs/wallet-ui/src/components/interaction-manager/content/log.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/log.tsx
@@ -17,7 +17,6 @@ export const LogComponent = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleMessage = useCallback(
     once((event: Log) => {
-      console.log(flow, event)
       if (flow !== 'TRANSACTION_REVIEW') {
         AppToaster.show({
           message: event.data.message,

--- a/libs/wallet-ui/src/components/interaction-manager/content/log.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/log.tsx
@@ -1,13 +1,8 @@
 import { useEffect, useCallback } from 'react'
 import { once } from 'ramda'
 
-import { Intent } from '../../../config/intent'
 import { AppToaster } from '../../toaster'
-import type {
-  InteractionContentProps,
-  Log,
-  LogContent,
-} from '../../../types/interaction'
+import type { InteractionContentProps, Log } from '../../../types/interaction'
 import { useGlobal } from '../../../contexts/global/global-context'
 import { getMessageIntent } from '../../../lib/transactions'
 

--- a/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/transaction-end.tsx
@@ -2,8 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { omit } from 'ramda'
 
 import { useGlobal } from '../../../contexts/global/global-context'
-import type {
-  Transaction} from '../../../lib/transactions';
+import type { Transaction } from '../../../lib/transactions'
 import {
   TransactionStatus,
   TRANSACTION_TITLES,

--- a/libs/wallet-ui/src/components/interaction-manager/content/transaction.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/content/transaction.tsx
@@ -3,8 +3,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useGlobal } from '../../../contexts/global/global-context'
 import {
   parseTransactionInput,
-  TransactionKeys,
   TransactionStatus,
+  TRANSACTION_TITLES,
+  TRANSACTION_DESCRIPTIONS,
 } from '../../../lib/transactions'
 import { Button } from '../../button'
 import { ButtonGroup } from '../../button-group'
@@ -14,60 +15,6 @@ import type {
   InteractionContentProps,
   RequestTransactionReview,
 } from '../../../types/interaction'
-
-export const TRANSACTION_TITLES: Record<TransactionKeys, string> = {
-  [TransactionKeys.UNKNOWN]: 'Unknown transaction',
-  [TransactionKeys.ORDER_SUBMISSION]: 'Order submission',
-  [TransactionKeys.ORDER_CANCELLATION]: 'Order cancellation',
-  [TransactionKeys.ORDER_AMENDMENT]: 'Order amendment',
-  [TransactionKeys.VOTE_SUBMISSION]: 'Vote submission',
-  [TransactionKeys.WITHDRAW_SUBMISSION]: 'Withdraw submission',
-  [TransactionKeys.LIQUIDTY_PROVISION_SUBMISSION]: 'Liquidity provision',
-  [TransactionKeys.LIQUIDTY_PROVISION_CANCELLATION]:
-    'Liquidity provision cancellation',
-  [TransactionKeys.LIQUIDITY_PROVISION_AMENDMENT]:
-    'Liquidity provision amendment',
-  [TransactionKeys.PROPOSAL_SUBMISSION]: 'Proposal submission',
-  [TransactionKeys.ANNOUNCE_NODE]: 'Announce node',
-  [TransactionKeys.NODE_VOTE]: 'Node vote',
-  [TransactionKeys.NODE_SIGNATURE]: 'Node signature',
-  [TransactionKeys.CHAIN_EVENT]: 'Chain event',
-  [TransactionKeys.ORACLE_DATA_SUBMISSION]: 'Oracle data submission',
-  [TransactionKeys.UNDELEGATE_SUBMISSION]: 'Undelegate submission',
-  [TransactionKeys.DELEGATE_SUBMISSION]: 'Delegate submission',
-  [TransactionKeys.TRANSFER]: 'Transfer',
-  [TransactionKeys.CANCEL_TRANSFER]: 'Cancel transfer',
-  [TransactionKeys.KEY_ROTATE_SUBMISSION]: 'Key rotation submission',
-  [TransactionKeys.ETHEREUM_KEY_ROTATE_SUBMISSION]:
-    'Ethereum key rotation submission',
-}
-
-const TRANSACTION_DESCRIPTIONS: Record<TransactionKeys, string> = {
-  [TransactionKeys.UNKNOWN]: 'submit an unknown transaction',
-  [TransactionKeys.ORDER_SUBMISSION]: 'submit an order',
-  [TransactionKeys.ORDER_CANCELLATION]: 'cancel an order',
-  [TransactionKeys.ORDER_AMENDMENT]: 'amend an order',
-  [TransactionKeys.VOTE_SUBMISSION]: 'submit a vote for a governance proposal',
-  [TransactionKeys.WITHDRAW_SUBMISSION]: 'withdraw funds',
-  [TransactionKeys.LIQUIDTY_PROVISION_SUBMISSION]: 'provide liquidity',
-  [TransactionKeys.LIQUIDTY_PROVISION_CANCELLATION]:
-    'cancel a liquidity provision',
-  [TransactionKeys.LIQUIDITY_PROVISION_AMENDMENT]:
-    'amend a liquidity provision',
-  [TransactionKeys.PROPOSAL_SUBMISSION]: 'submit a governance proposal',
-  [TransactionKeys.ANNOUNCE_NODE]: 'announce a node',
-  [TransactionKeys.NODE_VOTE]: 'submit a node vote',
-  [TransactionKeys.NODE_SIGNATURE]: 'submit a node signature',
-  [TransactionKeys.CHAIN_EVENT]: 'submit a chain event',
-  [TransactionKeys.ORACLE_DATA_SUBMISSION]: 'submit oracle data',
-  [TransactionKeys.UNDELEGATE_SUBMISSION]: 'undelegate stake to a node',
-  [TransactionKeys.DELEGATE_SUBMISSION]: 'delegate stake to a node',
-  [TransactionKeys.TRANSFER]: 'transfer assets',
-  [TransactionKeys.CANCEL_TRANSFER]: 'cancel a recurring transfer',
-  [TransactionKeys.KEY_ROTATE_SUBMISSION]: 'submit a key rotation',
-  [TransactionKeys.ETHEREUM_KEY_ROTATE_SUBMISSION]:
-    'submit an Ethereum key rotation',
-}
 
 export const Transaction = ({
   event,
@@ -104,6 +51,11 @@ export const Transaction = ({
             ...transaction,
             status: TransactionStatus.REJECTED,
           },
+        })
+      } else {
+        dispatch({
+          type: 'SHOW_TRANSACTION_DETAILS',
+          id: event.traceID,
         })
       }
     },

--- a/libs/wallet-ui/src/components/interaction-manager/interaction-flow.tsx
+++ b/libs/wallet-ui/src/components/interaction-manager/interaction-flow.tsx
@@ -180,6 +180,9 @@ const getEventFlowType = (events: Interaction[]) => {
       case INTERACTION_TYPE.REQUEST_PERMISSIONS_REVIEW: {
         return acc || EVENT_FLOW_TYPE.PERMISSION_REQUEST
       }
+      case INTERACTION_TYPE.REQUEST_TRANSACTION_REVIEW_FOR_SENDING: {
+        return acc || EVENT_FLOW_TYPE.TRANSACTION_REVIEW
+      }
       default: {
         return acc
       }

--- a/libs/wallet-ui/src/components/service-loader/service-loader.tsx
+++ b/libs/wallet-ui/src/components/service-loader/service-loader.tsx
@@ -38,7 +38,6 @@ export function ServiceLoader({ children }: { children?: ReactNode }) {
 
   useEffect(() => {
     service.EventsOn(EVENTS.SERVICE_HEALTHY, () => {
-      console.log('service.EventsOn(EVENTS.SERVICE_HEALTHY')
       setServiceError(null)
       dispatch({
         type: 'SET_SERVICE_STATUS',
@@ -47,7 +46,6 @@ export function ServiceLoader({ children }: { children?: ReactNode }) {
     })
 
     service.EventsOn(EVENTS.SERVICE_UNREACHABLE, () => {
-      console.log('service.EventsOn(EVENTS.SERVICE_UNREACHABLE')
       dispatch({
         type: 'SET_SERVICE_STATUS',
         status: ServiceState.Unreachable,
@@ -55,7 +53,6 @@ export function ServiceLoader({ children }: { children?: ReactNode }) {
     })
 
     service.EventsOn(EVENTS.SERVICE_UNHEALTHY, () => {
-      console.log('service.EventsOn(EVENTS.SERVICE_UNHEALTHY')
       dispatch({
         type: 'SET_SERVICE_STATUS',
         status: ServiceState.Unhealthy,
@@ -63,7 +60,6 @@ export function ServiceLoader({ children }: { children?: ReactNode }) {
     })
 
     service.EventsOn(EVENTS.SERVICE_STOPPED_WITH_ERROR, (err: Error) => {
-      console.log('service.EventsOn(EVENTS.SERVICE_STOPPED_WITH_ERROR', err)
       dispatch({
         type: 'SET_SERVICE_STATUS',
         status: ServiceState.Error,
@@ -76,7 +72,6 @@ export function ServiceLoader({ children }: { children?: ReactNode }) {
     })
 
     service.EventsOn(EVENTS.SERVICE_STOPPED, () => {
-      console.log('service.EventsOn(EVENTS.SERVICE_STOPPED')
       dispatch({
         type: 'SET_SERVICE_STATUS',
         status: ServiceState.Stopped,

--- a/libs/wallet-ui/src/components/transaction-details-dialog/index.ts
+++ b/libs/wallet-ui/src/components/transaction-details-dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction-details-dialog'

--- a/libs/wallet-ui/src/components/transaction-details-dialog/transaction-details-dialog.tsx
+++ b/libs/wallet-ui/src/components/transaction-details-dialog/transaction-details-dialog.tsx
@@ -1,0 +1,40 @@
+import { useMemo, useCallback } from 'react'
+
+import { useGlobal } from '../../contexts/global/global-context'
+import { Dialog } from '../dialog'
+import { ButtonGroup } from '../button-group'
+import { ButtonUnstyled } from '../button-unstyled'
+import { TransactionDetails } from '../transaction-details'
+import { TRANSACTION_TITLES } from '../../lib/transactions'
+
+export const TransactionDetailsDialog = () => {
+  const { state, dispatch } = useGlobal()
+  const transaction = useMemo(() => {
+    return (
+      state.showTransactionDetails !== '' &&
+      state.showTransactionDetails !== null &&
+      state.transactions[state.showTransactionDetails]
+    )
+  }, [state.transactions, state.showTransactionDetails])
+
+  const changeHandler = useCallback(() => {
+    dispatch({
+      type: 'SHOW_TRANSACTION_DETAILS',
+      id: null,
+    })
+  }, [dispatch])
+
+  return (
+    <Dialog
+      size="lg"
+      open={!!transaction}
+      title={transaction ? TRANSACTION_TITLES[transaction.type] : ''}
+      onChange={changeHandler}
+    >
+      {transaction && <TransactionDetails transaction={transaction} />}
+      <ButtonGroup inline className="p-[20px]">
+        <ButtonUnstyled onClick={() => changeHandler()}>Close</ButtonUnstyled>
+      </ButtonGroup>
+    </Dialog>
+  )
+}

--- a/libs/wallet-ui/src/components/transaction-details/transaction-details.tsx
+++ b/libs/wallet-ui/src/components/transaction-details/transaction-details.tsx
@@ -91,8 +91,12 @@ const compileSectionList = ({
       key: (
         <>
           <span>Event log</span>
-          <ButtonUnstyled onClick={onViewLogs}>
-            <DropdownArrow className="ml-[10px] w-[10px]" />
+          <ButtonUnstyled className="ml-[10px]" onClick={onViewLogs}>
+            <DropdownArrow
+              className={classnames('w-[10px]', {
+                'rotate-180': isLogSectionVisible,
+              })}
+            />
           </ButtonUnstyled>
         </>
       ),
@@ -125,8 +129,12 @@ const compileSectionList = ({
     key: (
       <>
         <span>Transaction details</span>
-        <ButtonUnstyled onClick={onViewDetails}>
-          <DropdownArrow className="ml-[10px] w-[10px]" />
+        <ButtonUnstyled className="ml-[10px]" onClick={onViewDetails}>
+          <DropdownArrow
+            className={classnames('w-[10px]', {
+              'rotate-180': isDetailSectionVisible,
+            })}
+          />
         </ButtonUnstyled>
       </>
     ),

--- a/libs/wallet-ui/src/components/transaction-details/transaction-details.tsx
+++ b/libs/wallet-ui/src/components/transaction-details/transaction-details.tsx
@@ -14,7 +14,6 @@ import { DropdownArrow } from '../icons/dropdown-arrow'
 import { Title } from '../title'
 import { ExternalLink } from '../external-link'
 import { TransactionStatus } from '../transaction-status'
-import { getMessageIntent, TRANSACTION_TITLES } from '../../lib/transactions'
 
 type TransactionDetailsProps = {
   transaction: Transaction

--- a/libs/wallet-ui/src/components/transaction-history/transaction-history.tsx
+++ b/libs/wallet-ui/src/components/transaction-history/transaction-history.tsx
@@ -1,58 +1,42 @@
-import { useState } from 'react'
+import { useMemo, useCallback } from 'react'
 
 import { useCurrentKeypair } from '../../hooks/use-current-keypair'
-import { useExplorerUrl } from '../../hooks/use-explorer-url'
-import type { Transaction } from '../../lib/transactions'
+import { useGlobal } from '../../contexts/global/global-context'
 import { sortTransaction } from '../../lib/transactions'
-import { AnchorButton } from '../button'
-import { ButtonGroup } from '../button-group'
-import { ButtonUnstyled } from '../button-unstyled'
-import { Dialog } from '../dialog'
-import { TRANSACTION_TITLES } from '../interaction-manager/content/transaction'
-import { TransactionDetails } from '../transaction-details'
 import { TransactionItem } from './transaction-item'
 
 export const TransactionHistory = () => {
-  const explorerUrl = useExplorerUrl()
   const { keypair } = useCurrentKeypair()
-  const [transaction, setTransaction] = useState<Transaction | null>(null)
-  const transactionList = Object.values(keypair?.transactions || []).sort(
-    sortTransaction
+  const { state, dispatch } = useGlobal()
+  const transactionList = useMemo(
+    () =>
+      Object.values(state.transactions || [])
+        .filter((t) => t.publicKey === keypair?.publicKey)
+        .sort(sortTransaction),
+    [state.transactions, keypair?.publicKey]
+  )
+
+  const onViewDetailsHandler = useCallback(
+    (id: string) => {
+      dispatch({
+        type: 'SHOW_TRANSACTION_DETAILS',
+        id,
+      })
+    },
+    [dispatch]
   )
 
   return (
     <>
       {transactionList.length === 0 && <div>No transactions in history.</div>}
       {transactionList.length > 0 &&
-        transactionList.map((item, index) => (
+        transactionList.map((item) => (
           <TransactionItem
-            key={index}
+            key={item.id}
             transaction={item}
-            viewDetails={() => setTransaction(item)}
+            viewDetails={() => onViewDetailsHandler(item.id)}
           />
         ))}
-      <Dialog
-        size="lg"
-        open={!!transaction}
-        title={transaction ? TRANSACTION_TITLES[transaction.type] : ''}
-        onChange={(open) => setTransaction(open ? transaction : null)}
-      >
-        {transaction && <TransactionDetails transaction={transaction} />}
-        <ButtonGroup inline className="p-[20px]">
-          {explorerUrl && transaction?.txHash && (
-            <AnchorButton
-              href={`${explorerUrl}/txs/${transaction.txHash}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View in explorer
-            </AnchorButton>
-          )}
-          <ButtonUnstyled onClick={() => setTransaction(null)}>
-            Close
-          </ButtonUnstyled>
-        </ButtonGroup>
-      </Dialog>
     </>
   )
 }

--- a/libs/wallet-ui/src/components/transaction-history/transaction-item.tsx
+++ b/libs/wallet-ui/src/components/transaction-history/transaction-item.tsx
@@ -2,10 +2,10 @@ import { useExplorerUrl } from '../../hooks/use-explorer-url'
 import { formatDate } from '../../lib/date'
 import type { Transaction } from '../../lib/transactions'
 import { truncateMiddle } from '../../lib/truncate-middle'
+import { TRANSACTION_TITLES } from '../../lib/transactions'
 import { ButtonUnstyled } from '../button-unstyled'
 import { ExternalLink } from '../external-link'
 import { ArrowTopRight } from '../icons/arrow-top-right'
-import { TRANSACTION_TITLES } from '../interaction-manager/content/transaction'
 import { TransactionStatus } from '../transaction-status'
 
 type TransactionItemProps = {

--- a/libs/wallet-ui/src/contexts/global/global-context.ts
+++ b/libs/wallet-ui/src/contexts/global/global-context.ts
@@ -63,7 +63,6 @@ export interface KeyPair
   name: string
   publicKeyShort: string
   meta: WalletModel.DescribeKeyResult['metadata']
-  transactions: Record<string, Transaction>
 }
 
 export interface Wallet {
@@ -82,6 +81,7 @@ export interface GlobalState {
   // Wallet
   wallet: string | null
   wallets: Record<string, Wallet>
+  transactions: Record<string, Transaction>
 
   // Network
   currentNetwork: string | null
@@ -103,6 +103,7 @@ export interface GlobalState {
   isUpdateKeyModalOpen: boolean
   isSettingsModalOpen: boolean
   isNetworkCompatibilityModalOpen: boolean
+  showTransactionDetails: null | string
 }
 
 export type GlobalDispatch = ThunkDispatch<GlobalState, GlobalAction>

--- a/libs/wallet-ui/src/contexts/global/global-reducer.ts
+++ b/libs/wallet-ui/src/contexts/global/global-reducer.ts
@@ -5,6 +5,7 @@ import { indexBy } from '../../lib/index-by'
 import type { Transaction } from '../../lib/transactions'
 import { extendKeypair } from '../../lib/wallet-helpers'
 import type { AppConfig, GetVersionResponse } from '../../types/service'
+import type { LogContent } from '../../types/interaction'
 
 import type {
   Connection,
@@ -24,6 +25,7 @@ export const initialGlobalState: GlobalState = {
   // Wallet
   wallet: null,
   wallets: {},
+  transactions: {},
 
   // Network
   currentNetwork: null,
@@ -48,6 +50,7 @@ export const initialGlobalState: GlobalState = {
   isUpdateKeyModalOpen: false,
   isSettingsModalOpen: false,
   isNetworkCompatibilityModalOpen: false,
+  showTransactionDetails: null,
 }
 
 export type GlobalAction =
@@ -176,13 +179,19 @@ export type GlobalAction =
       type: 'SET_SERVICE_URL'
       url: string
     }
+  // Transactions
   | {
       type: 'ADD_TRANSACTION'
       transaction: Transaction
     }
   | {
       type: 'UPDATE_TRANSACTION'
-      transaction: Transaction
+      transaction: Partial<Transaction> & Pick<Transaction, 'id'>
+    }
+  | {
+      type: 'ADD_TRANSACTION_LOG'
+      id: string
+      log: LogContent
     }
   // Connections
   | {
@@ -223,6 +232,10 @@ export type GlobalAction =
   | {
       type: 'SET_NETWORK_COMPATIBILITY_MODAL'
       open: boolean
+    }
+  | {
+      type: 'SHOW_TRANSACTION_DETAILS'
+      id: string | null
     }
 
 export function globalReducer(
@@ -539,41 +552,45 @@ export function globalReducer(
         httpServiceUrl: action.url,
       }
     }
-    case 'ADD_TRANSACTION':
-    case 'UPDATE_TRANSACTION': {
-      const targetWallet = state.wallets[action.transaction.wallet]
-
-      if (!targetWallet) {
-        throw new Error('Wallet not found')
-      }
-
-      const keypair = targetWallet.keypairs?.[action.transaction.publicKey]
-
-      if (!keypair) {
-        throw new Error('Public key not found')
-      }
-
-      const updatedWallet: Wallet = {
-        ...targetWallet,
-        keypairs: {
-          ...targetWallet.keypairs,
-          [action.transaction.publicKey]: {
-            ...keypair,
-            transactions: {
-              ...keypair.transactions,
-              [action.transaction.id]: action.transaction,
-            },
-          },
-        },
-      }
-
+    case 'ADD_TRANSACTION': {
       return {
         ...state,
-        wallets: {
-          ...state.wallets,
-          [action.transaction.wallet]: updatedWallet,
+        transactions: {
+          ...state.transactions,
+          [action.transaction.id]: action.transaction,
         },
       }
+    }
+    case 'UPDATE_TRANSACTION': {
+      if (state.transactions[action.transaction.id]) {
+        return {
+          ...state,
+          transactions: {
+            ...state.transactions,
+            [action.transaction.id]: {
+              ...state.transactions[action.transaction.id],
+              ...action.transaction,
+            },
+          },
+        }
+      }
+      return state
+    }
+    case 'ADD_TRANSACTION_LOG': {
+      if (state.transactions[action.id]) {
+        const transaction = state.transactions[action.id]
+        return {
+          ...state,
+          transactions: {
+            ...state.transactions,
+            [action.id]: {
+              ...transaction,
+              logs: [...transaction.logs, action.log],
+            },
+          },
+        }
+      }
+      return state
     }
     // Connections
     case 'ADD_CONNECTION': {
@@ -648,6 +665,12 @@ export function globalReducer(
       return {
         ...state,
         isNetworkCompatibilityModalOpen: action.open,
+      }
+    }
+    case 'SHOW_TRANSACTION_DETAILS': {
+      return {
+        ...state,
+        showTransactionDetails: action.id,
       }
     }
     default: {

--- a/libs/wallet-ui/src/index.tsx
+++ b/libs/wallet-ui/src/index.tsx
@@ -9,6 +9,7 @@ import { Chrome } from './components/chrome'
 import { InteractionManager } from './components/interaction-manager'
 import { NetworkCompatibilityDialog } from './components/network-compatibility-dialog'
 import { PassphraseModal } from './components/passphrase-modal'
+import { TransactionDetailsDialog } from './components/transaction-details-dialog'
 import { Settings } from './components/settings'
 import { SplashError } from './components/splash-error'
 import { TelemetryDialog } from './components/telemetry-dialog'
@@ -61,6 +62,7 @@ export function App({ service, client, runtime, features }: AppProps) {
                     <PassphraseModal />
                     <InteractionManager />
                     <NetworkCompatibilityDialog />
+                    <TransactionDetailsDialog />
                     <Settings />
                   </AppLoader>
                 </Chrome>

--- a/libs/wallet-ui/src/lib/transactions.ts
+++ b/libs/wallet-ui/src/lib/transactions.ts
@@ -1,6 +1,7 @@
 import { omit } from 'ramda'
 
-import type { RequestTransactionReview } from '../types/interaction'
+import type { LogContent, RequestTransactionReview } from '../types/interaction'
+import { Intent } from '../config/intent'
 
 export enum TransactionStatus {
   PENDING = 'pending',
@@ -44,10 +45,65 @@ export type Transaction = {
   payload: TransactionData
   status: TransactionStatus
   receivedAt: Date
+  logs: LogContent[]
   txHash?: null | string
   blockHeight?: number
   signature?: string
   error?: string
+}
+
+export const TRANSACTION_TITLES: Record<TransactionKeys, string> = {
+  [TransactionKeys.UNKNOWN]: 'Unknown transaction',
+  [TransactionKeys.ORDER_SUBMISSION]: 'Order submission',
+  [TransactionKeys.ORDER_CANCELLATION]: 'Order cancellation',
+  [TransactionKeys.ORDER_AMENDMENT]: 'Order amendment',
+  [TransactionKeys.VOTE_SUBMISSION]: 'Vote submission',
+  [TransactionKeys.WITHDRAW_SUBMISSION]: 'Withdraw submission',
+  [TransactionKeys.LIQUIDTY_PROVISION_SUBMISSION]: 'Liquidity provision',
+  [TransactionKeys.LIQUIDTY_PROVISION_CANCELLATION]:
+    'Liquidity provision cancellation',
+  [TransactionKeys.LIQUIDITY_PROVISION_AMENDMENT]:
+    'Liquidity provision amendment',
+  [TransactionKeys.PROPOSAL_SUBMISSION]: 'Proposal submission',
+  [TransactionKeys.ANNOUNCE_NODE]: 'Announce node',
+  [TransactionKeys.NODE_VOTE]: 'Node vote',
+  [TransactionKeys.NODE_SIGNATURE]: 'Node signature',
+  [TransactionKeys.CHAIN_EVENT]: 'Chain event',
+  [TransactionKeys.ORACLE_DATA_SUBMISSION]: 'Oracle data submission',
+  [TransactionKeys.UNDELEGATE_SUBMISSION]: 'Undelegate submission',
+  [TransactionKeys.DELEGATE_SUBMISSION]: 'Delegate submission',
+  [TransactionKeys.TRANSFER]: 'Transfer',
+  [TransactionKeys.CANCEL_TRANSFER]: 'Cancel transfer',
+  [TransactionKeys.KEY_ROTATE_SUBMISSION]: 'Key rotation submission',
+  [TransactionKeys.ETHEREUM_KEY_ROTATE_SUBMISSION]:
+    'Ethereum key rotation submission',
+}
+
+export const TRANSACTION_DESCRIPTIONS: Record<TransactionKeys, string> = {
+  [TransactionKeys.UNKNOWN]: 'submit an unknown transaction',
+  [TransactionKeys.ORDER_SUBMISSION]: 'submit an order',
+  [TransactionKeys.ORDER_CANCELLATION]: 'cancel an order',
+  [TransactionKeys.ORDER_AMENDMENT]: 'amend an order',
+  [TransactionKeys.VOTE_SUBMISSION]: 'submit a vote for a governance proposal',
+  [TransactionKeys.WITHDRAW_SUBMISSION]: 'withdraw funds',
+  [TransactionKeys.LIQUIDTY_PROVISION_SUBMISSION]: 'provide liquidity',
+  [TransactionKeys.LIQUIDTY_PROVISION_CANCELLATION]:
+    'cancel a liquidity provision',
+  [TransactionKeys.LIQUIDITY_PROVISION_AMENDMENT]:
+    'amend a liquidity provision',
+  [TransactionKeys.PROPOSAL_SUBMISSION]: 'submit a governance proposal',
+  [TransactionKeys.ANNOUNCE_NODE]: 'announce a node',
+  [TransactionKeys.NODE_VOTE]: 'submit a node vote',
+  [TransactionKeys.NODE_SIGNATURE]: 'submit a node signature',
+  [TransactionKeys.CHAIN_EVENT]: 'submit a chain event',
+  [TransactionKeys.ORACLE_DATA_SUBMISSION]: 'submit oracle data',
+  [TransactionKeys.UNDELEGATE_SUBMISSION]: 'undelegate stake to a node',
+  [TransactionKeys.DELEGATE_SUBMISSION]: 'delegate stake to a node',
+  [TransactionKeys.TRANSFER]: 'transfer assets',
+  [TransactionKeys.CANCEL_TRANSFER]: 'cancel a recurring transfer',
+  [TransactionKeys.KEY_ROTATE_SUBMISSION]: 'submit a key rotation',
+  [TransactionKeys.ETHEREUM_KEY_ROTATE_SUBMISSION]:
+    'submit an Ethereum key rotation',
 }
 
 const getPayload = (transaction: string): TransactionData => {
@@ -79,6 +135,7 @@ export const parseTransactionInput = (
     receivedAt: new Date(event.data.receivedAt),
     wallet: event.data.wallet,
     publicKey: event.data.publicKey,
+    logs: [],
     txHash: null,
   }
 }
@@ -87,4 +144,21 @@ export const sortTransaction = (a: Transaction, b: Transaction) => {
   if (a.receivedAt < b.receivedAt) return -1
   if (a.receivedAt > b.receivedAt) return 1
   return 0
+}
+
+export const getMessageIntent = (type: LogContent['type']) => {
+  switch (type) {
+    case 'Error': {
+      return Intent.DANGER
+    }
+    case 'Warning': {
+      return Intent.WARNING
+    }
+    case 'Success': {
+      return Intent.SUCCESS
+    }
+    default: {
+      return Intent.NONE
+    }
+  }
 }

--- a/libs/wallet-ui/src/lib/wallet-helpers.ts
+++ b/libs/wallet-ui/src/lib/wallet-helpers.ts
@@ -10,7 +10,6 @@ export function extendKeypair(kp: WalletModel.DescribeKeyResult): KeyPair {
     publicKey: kp.publicKey,
     meta: kp.metadata,
     name: nameMeta?.value || 'No name',
-    transactions: {},
     publicKeyShort,
   }
 }

--- a/libs/wallet-ui/src/types/service.ts
+++ b/libs/wallet-ui/src/types/service.ts
@@ -1,4 +1,3 @@
-import type { EVENTS } from '../lib/events'
 import type { RawInteraction, InteractionResponse } from './interaction'
 import type { Logger } from './logger'
 

--- a/libs/wallet-ui/src/types/service.ts
+++ b/libs/wallet-ui/src/types/service.ts
@@ -55,13 +55,34 @@ export type AppConfig = {
 
 type Empty = void | undefined | Error
 
+export type EventType =
+  | 'new_interaction'
+  // Sent when the service is healthy.
+  // This event can be emitted every 15 seconds.
+  | 'service_is_healthy'
+  // Sent when no service is running anymore.
+  // This event can be emitted every 15 seconds.
+  | 'service_unreachable'
+  // Sent when the service is unhealthy, meaning we could connect but the endpoint
+  // didn't answer what we expected. More in the application logs.
+  // This event can be emitted every 15 seconds.
+  | 'service_is_unhealthy'
+  // Sent when the service unexpectedly stopped, internal crash.
+  // This event is emitted once per service lifecycle.
+  // If emitted, the `ServiceStopped` is not be emitted.
+  | 'service_stopped_with_error'
+  // Sent when the service has been stopped by the user.
+  // This event is emitted once per service lifecycle.
+  // If emitted, the `ServiceStoppedWithError` is not be emitted.
+  | 'service_stopped'
+
 type EventsCallbackArgs =
-  | [EVENTS.NEW_INTERACTION_EVENT, (interaction: RawInteraction) => void]
-  | [EVENTS.SERVICE_HEALTHY, () => void]
-  | [EVENTS.SERVICE_UNREACHABLE, () => void]
-  | [EVENTS.SERVICE_UNHEALTHY, () => void]
-  | [EVENTS.SERVICE_STOPPED_WITH_ERROR, (err: Error) => void]
-  | [EVENTS.SERVICE_STOPPED, () => void]
+  | ['new_interaction', (interaction: RawInteraction) => void]
+  | ['service_is_healthy', () => void]
+  | ['service_unreachable', () => void]
+  | ['service_is_unhealthy', () => void]
+  | ['service_stopped_with_error', (err: Error) => void]
+  | ['service_stopped', () => void]
 
 type EventsCallback = (...args: EventsCallbackArgs) => void
 
@@ -97,6 +118,6 @@ export type Service = {
 
   // API
   EventsOn: EventsCallback
-  EventsOff: (...name: EVENTS[]) => void
+  EventsOff: (...name: EventType[]) => void
   RespondToInteraction: (arg: InteractionResponse) => Promise<Empty>
 }


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/487

# Description ℹ️

Implement a transaction log component, which would collect the log events from a transaction interaction. 

# Demo 📺

https://user-images.githubusercontent.com/105208209/221640356-b8dea8b3-284e-40fe-a9fc-c222775b8de3.mp4


# Technical 👨‍🔧

Changed a few functional bits:

- current transaction details view opens when approving a transaction
- transactions data is now stored centrally on the redux store, instead of per keypair, in preparation for the future centralised view (-> https://github.com/vegaprotocol/vegawallet-desktop/issues/488)

<img width="601" alt="Screenshot 2023-02-28 at 12 23 06" src="https://user-images.githubusercontent.com/105208209/221853351-e999c78a-100f-4d46-b201-9b9c20cdf89f.png">
<img width="601" alt="Screenshot 2023-02-28 at 12 23 17" src="https://user-images.githubusercontent.com/105208209/221853359-afe4f945-692d-44b0-b57e-c68255b34114.png">

