### PR TITLE
feat: add transactions generation to generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,20 +19,34 @@ jobs:
           key: node_modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install root dependencies
         run: yarn install --frozen-lockfile
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+      - name: Clone vega
+        run: git clone git@github.com:vegaprotocol/vega.git
+      - name: Regenerate transactions interface
+        run: |
+          yarn nx run transactions:generate \
+          rm -rf vega \
+        with: WALLET_TRANSACTIONS_ROOT=./vega/protos/sources
+          WALLET_TRANSACTIONS_SOURCE=./vega/protos/sources/vega/commands/v1/commands.proto
       - name: Regenerate the wallet admin
         run: yarn nx run wallet-admin:generate
         with: WALLET_ADMIN_SPECS={{ github.event.data.source }}
       - name: Regenerate the wallet client
         run: yarn nx run wallet-client:generate
         with: WALLET_CLIENT_SPECS={{ github.event.data.source }}
+      - name: Lint
+        run: yarn nx affected --target=lint --fix
+      - name: Format
+        run: yarn nx format:write
       - name: Bump the library versions
-        run: yarn nx run-many target=bump
+        run: yarn nx affected --target=bump
       - name: Update readmes
         run: |
           node ./scripts/bump-readme --project=wallet-client --version={{ github.event.data.version }} \
           node ./scripts/bump-readme --project=wallet-admin --version={{ github.event.data.version }} \
-      - name: Format
-        run: yarn nx format:write
       - name: Create PR
         uses: peter-evans/create-pull-request@v4
         with:

--- a/libs/wallet-ui/project.json
+++ b/libs/wallet-ui/project.json
@@ -159,6 +159,13 @@
           "buildTarget": "wallet-ui:build:test"
         }
       }
+    },
+    "bump": {
+      "executor": "nx:run-commands",
+      "outputs": [],
+      "options": {
+        "command": "node ./scripts/version-package --project=wallet-ui"
+      }
     }
   }
 }


### PR DESCRIPTION
# Related issues 🔗

Closes #97 

# Description ℹ️

Regenerate automated code when vega gets tagged.

The intended full workflow:

- install node dependencies
- install `protoc`
- clone https://github.com/vegaprotocol/vega
- regenerate `libs/transactions` as described in https://github.com/vegaprotocol/vegawallet-ui/tree/main/libs/transactions (requires a local clone of vega and protoc to be installed)
- delete the local vega clone
- regenerate `wallet-admin`
- regenerate `wallet-client`
- fix lint and format
- bump the versions of the affected libraries
- create a new PR with the change diff


The data needed from the vega repo i've assumed would be accessbile from the webhook event itself:
```
data: {
  version: '<X.X.X>'        // the version of the new tag on vega
  source: 'https://raw.githubusercontent.com/vegaprotocol/vega/<X.X.X>/wallet/api/openrpc.json'   // url pointing to the openrpc file of the wallet api from the new tag
}

```