### PR TITLE
fix: dapp urls field validation

### DIFF
--- a/libs/wallet-ui/src/components/network-config-form/network-config-form.tsx
+++ b/libs/wallet-ui/src/components/network-config-form/network-config-form.tsx
@@ -76,7 +76,7 @@ export const NetworkConfigForm = ({
           data-testid="network-console-url"
           type="text"
           {...register('consoleUrl', {
-            required: Validation.REQUIRED,
+            pattern: Validation.URL,
           })}
         />
       </FormGroup>
@@ -90,7 +90,7 @@ export const NetworkConfigForm = ({
           data-testid="network-explorer-url"
           type="text"
           {...register('explorerUrl', {
-            required: Validation.REQUIRED,
+            pattern: Validation.URL,
           })}
         />
       </FormGroup>
@@ -104,7 +104,7 @@ export const NetworkConfigForm = ({
           data-testid="network-token-url"
           type="text"
           {...register('tokenUrl', {
-            required: Validation.REQUIRED,
+            pattern: Validation.URL,
           })}
         />
       </FormGroup>


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/529 

# Description ℹ️

Unset the required prop from the input validation of the dapp url fields. 
