### PR TITLE
fix: set network name as non-editable

### DIFF
--- a/libs/wallet-ui/src/components/forms/input.tsx
+++ b/libs/wallet-ui/src/components/forms/input.tsx
@@ -19,7 +19,10 @@ export const Input = forwardRef(
         autoCorrect="off"
         autoComplete="off"
         className={classnames(
-          getDefaultClassName({ hasError: props['aria-invalid'] === 'true' }),
+          getDefaultClassName({
+            hasError: props['aria-invalid'] === 'true',
+            isDisabled: props.disabled,
+          }),
           className
         )}
       />

--- a/libs/wallet-ui/src/components/forms/styles.ts
+++ b/libs/wallet-ui/src/components/forms/styles.ts
@@ -2,8 +2,10 @@ import classnames from 'classnames'
 
 export const getDefaultClassName = ({
   hasError = false,
+  isDisabled = false,
 }: {
   hasError?: boolean
+  isDisabled?: boolean
 }) => {
   return classnames(
     'block appearance-none w-full bg-transparent',
@@ -13,6 +15,8 @@ export const getDefaultClassName = ({
       'outline-white': !hasError,
       'border-red': hasError,
       'border-white': !hasError,
+      'border-neutral': isDisabled,
+      'text-neutral': isDisabled,
     }
   )
 }

--- a/libs/wallet-ui/src/components/network-config-form/network-config-form.tsx
+++ b/libs/wallet-ui/src/components/network-config-form/network-config-form.tsx
@@ -61,6 +61,7 @@ export const NetworkConfigForm = ({
         <Input
           data-testid="network-name"
           type="text"
+          disabled={true}
           {...register('name', {
             required: Validation.REQUIRED,
           })}

--- a/libs/wallet-ui/src/components/network-config-form/network-config-form.tsx
+++ b/libs/wallet-ui/src/components/network-config-form/network-config-form.tsx
@@ -53,21 +53,6 @@ export const NetworkConfigForm = ({
       })}
     >
       <FormGroup
-        label="Network name"
-        labelFor="name"
-        intent={errors.name?.message ? Intent.DANGER : Intent.NONE}
-        helperText={errors.name?.message}
-      >
-        <Input
-          data-testid="network-name"
-          type="text"
-          disabled={true}
-          {...register('name', {
-            required: Validation.REQUIRED,
-          })}
-        />
-      </FormGroup>
-      <FormGroup
         label="Console dApp URL"
         labelFor="consoleUrl"
         intent={errors.consoleUrl?.message ? Intent.DANGER : Intent.NONE}


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/527

# Description ℹ️

Disables network name from editing.

# Demo 📺

<img width="519" alt="Screenshot 2023-02-28 at 15 27 30" src="https://user-images.githubusercontent.com/105208209/221899512-f3788399-b790-43a5-889d-f67fd1c5e22f.png">

