### PR TITLE
fix: enable disconnecting a wallet from a host

### DIFF
--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",

--- a/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
@@ -53,7 +53,7 @@ export const Disconnect = ({
         message: `${err}`,
       })
     }
-  }, [dispatch, setLoading, onClose])
+  }, [dispatch, client, wallet, hostname, setLoading, onClose])
 
   return (
     <div>

--- a/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
@@ -1,7 +1,11 @@
-import type { Wallet } from '../../contexts/global/global-context'
+import { useCallback, useState } from 'react'
+import type { Wallet } from '../../contexts/global/global-context';
+import { useGlobal } from '../../contexts/global/global-context'
 import { Button } from '../button'
 import { ButtonGroup } from '../button-group'
 import { ButtonUnstyled } from '../button-unstyled'
+import { AppToaster } from '../toaster'
+import { Intent } from '../../config/intent'
 
 type DisconnectDialogProps = {
   wallet: Wallet
@@ -14,9 +18,42 @@ export const Disconnect = ({
   hostname,
   onClose,
 }: DisconnectDialogProps) => {
-  // TODO: add client.DisconnectWallet({...}) when made available
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const handleDisconnect = () => {}
+  const [isLoading, setLoading] = useState(false)
+  const { client, dispatch } = useGlobal()
+
+  const handleDisconnect = useCallback(async () => {
+    setLoading(true)
+    try {
+      await client.CloseConnection({
+        wallet: wallet.name,
+        hostname,
+      })
+
+      const hostConnection = wallet.connections?.[hostname]
+
+      if (hostConnection) {
+        dispatch({
+          type: 'SET_CONNECTIONS',
+          wallet: wallet.name,
+          connections: {
+            ...wallet.connections,
+            [hostname]: {
+              ...hostConnection,
+              active: false,
+            },
+          },
+        })
+      }
+      setLoading(false)
+      onClose()
+    } catch (err) {
+      setLoading(false)
+      AppToaster.show({
+        intent: Intent.DANGER,
+        message: `${err}`,
+      })
+    }
+  }, [dispatch, setLoading, onClose])
 
   return (
     <div>
@@ -28,7 +65,9 @@ export const Disconnect = ({
         </p>
       </div>
       <ButtonGroup inline className="p-[20px]">
-        <Button onClick={handleDisconnect}>Disconnect</Button>
+        <Button loading={isLoading} onClick={handleDisconnect}>
+          Disconnect
+        </Button>
         <ButtonUnstyled onClick={onClose}>Cancel</ButtonUnstyled>
       </ButtonGroup>
     </div>

--- a/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import type { Wallet } from '../../contexts/global/global-context';
+import type { Wallet } from '../../contexts/global/global-context'
 import { useGlobal } from '../../contexts/global/global-context'
 import { Button } from '../button'
 import { ButtonGroup } from '../button-group'

--- a/libs/wallet-ui/src/components/connection-list/connection-item.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-item.tsx
@@ -6,12 +6,14 @@ import { StatusCircle } from '../status-circle'
 type ConnectionItemProps = {
   connection: Connection
   onManage: () => void
+  onRemove: () => void
   onDisconnect: () => void
 }
 
 export const ConnectionItem = ({
   connection,
   onManage,
+  onRemove,
   onDisconnect,
 }: ConnectionItemProps) => {
   return (
@@ -32,9 +34,12 @@ export const ConnectionItem = ({
       </div>
       <div className="flex gap-[20px]">
         <ButtonUnstyled onClick={onManage}>Manage</ButtonUnstyled>
-        <ButtonUnstyled className="hidden" onClick={onDisconnect}>
-          Disconnect
-        </ButtonUnstyled>
+        {connection.active && (
+          <ButtonUnstyled onClick={onDisconnect}>Disconnect</ButtonUnstyled>
+        )}
+        {!connection.active && (
+          <ButtonUnstyled onClick={onRemove}>Remove</ButtonUnstyled>
+        )}
       </div>
     </div>
   )

--- a/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
@@ -1,6 +1,6 @@
 import { omit } from 'ramda'
 import { useCallback, useState } from 'react'
-import type { Wallet } from '../../contexts/global/global-context';
+import type { Wallet } from '../../contexts/global/global-context'
 import { useGlobal } from '../../contexts/global/global-context'
 import { Button } from '../button'
 import { ButtonGroup } from '../button-group'

--- a/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
@@ -37,7 +37,7 @@ export const Remove = ({ wallet, hostname, onClose }: RemoveDialogProps) => {
     }
     setLoading(false)
     onClose()
-  }, [dispatch, hostname, wallet, setLoading, onClose])
+  }, [dispatch, client, hostname, wallet, setLoading, onClose])
 
   return (
     <div>

--- a/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
@@ -1,0 +1,59 @@
+import { omit } from 'ramda'
+import { useCallback, useState } from 'react'
+import type { Wallet } from '../../contexts/global/global-context';
+import { useGlobal } from '../../contexts/global/global-context'
+import { Button } from '../button'
+import { ButtonGroup } from '../button-group'
+import { ButtonUnstyled } from '../button-unstyled'
+import { requestPassphrase } from '..//passphrase-modal'
+
+type RemoveDialogProps = {
+  wallet: Wallet
+  hostname: string
+  onClose: () => void
+}
+
+export const Remove = ({ wallet, hostname, onClose }: RemoveDialogProps) => {
+  const [isLoading, setLoading] = useState(false)
+  const { client, dispatch } = useGlobal()
+
+  const handleRemoval = useCallback(async () => {
+    setLoading(true)
+    const hostConnection = wallet.connections?.[hostname]
+    const passphrase = await requestPassphrase()
+
+    await client.RevokePermissions({
+      wallet: wallet.name,
+      passphrase,
+      hostname,
+    })
+
+    if (hostConnection) {
+      dispatch({
+        type: 'SET_CONNECTIONS',
+        wallet: wallet.name,
+        connections: omit([hostname], wallet.connections),
+      })
+    }
+    setLoading(false)
+    onClose()
+  }, [dispatch, hostname, wallet, setLoading, onClose])
+
+  return (
+    <div>
+      <div className="p-[20px]">
+        <p>
+          Are you sure you want to remove the connection from your wallet{' '}
+          <code>{wallet.name}</code> to <code>{hostname}</code>? You may lose
+          site functionality.
+        </p>
+      </div>
+      <ButtonGroup inline className="p-[20px]">
+        <Button loading={isLoading} onClick={handleRemoval}>
+          Remove
+        </Button>
+        <ButtonUnstyled onClick={onClose}>Cancel</ButtonUnstyled>
+      </ButtonGroup>
+    </div>
+  )
+}

--- a/libs/wallet-ui/src/contexts/global/global-reducer.ts
+++ b/libs/wallet-ui/src/contexts/global/global-reducer.ts
@@ -117,7 +117,7 @@ export type GlobalAction =
   | {
       type: 'SET_CONNECTIONS'
       wallet: string
-      connections: Connection[]
+      connections: Record<string, Connection>
     }
   | {
       type: 'SET_PERMISSONS'
@@ -396,10 +396,7 @@ export function globalReducer(
 
       const updatedWallet: Wallet = {
         ...targetWallet,
-        connections: action.connections.reduce(
-          indexBy<Connection>('hostname'),
-          {}
-        ),
+        connections: action.connections,
       }
 
       return {

--- a/libs/wallet-ui/src/hooks/use-open-wallet.tsx
+++ b/libs/wallet-ui/src/hooks/use-open-wallet.tsx
@@ -1,4 +1,3 @@
-import { WalletModel } from '@vegaprotocol/wallet-admin'
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 

--- a/libs/wallet-ui/src/hooks/use-open-wallet.tsx
+++ b/libs/wallet-ui/src/hooks/use-open-wallet.tsx
@@ -4,7 +4,9 @@ import { useNavigate } from 'react-router-dom'
 import { requestPassphrase } from '../components/passphrase-modal'
 import { AppToaster } from '../components/toaster'
 import { Intent } from '../config/intent'
+import type { Connection } from '../contexts/global/global-context';
 import { useGlobal } from '../contexts/global/global-context'
+import { indexBy } from '../lib/index-by'
 
 export const useOpenWallet = () => {
   const navigate = useNavigate()
@@ -52,7 +54,10 @@ export const useOpenWallet = () => {
       dispatch({
         type: 'SET_CONNECTIONS',
         wallet,
-        connections: permissionDetails,
+        connections: permissionDetails.reduce<Record<string, Connection>>(
+          indexBy('hostname'),
+          {}
+        ),
       })
       dispatch({
         type: 'ACTIVATE_WALLET',

--- a/libs/wallet-ui/src/hooks/use-open-wallet.tsx
+++ b/libs/wallet-ui/src/hooks/use-open-wallet.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { requestPassphrase } from '../components/passphrase-modal'
 import { AppToaster } from '../components/toaster'
 import { Intent } from '../config/intent'
-import type { Connection } from '../contexts/global/global-context';
+import type { Connection } from '../contexts/global/global-context'
 import { useGlobal } from '../contexts/global/global-context'
 import { indexBy } from '../lib/index-by'
 


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/327

# Description ℹ️

- add a disconnect button for each active connection from the list - disconnecting uses the `admin.close_connection` endpoint, and makes the access token for the connection invalid
- add a remove button for each inactive connection from the list (inactive connection is just a permissions entry with read access to all / some keypairs of a wallet) - the actual removal here means to revoke the permissions for a hostname - the list of displayed connection entries is filtered by permissions !== "none"

Problems: there's currently no way to get rid of a permissions entry on the backend (created an issue for it: https://github.com/vegaprotocol/vega/issues/7721). Not sure how big a normal person's connection list would grow, but decided to hide connections which are both inactive and have all permissions disabled for a host, this makes it work on the UI for now. 

# Demo 📺

<img width="758" alt="Screenshot 2023-02-28 at 17 31 08" src="https://user-images.githubusercontent.com/105208209/221931710-090241a6-d7ae-4589-8ecc-36f772f375b1.png">
<img width="424" alt="Screenshot 2023-02-28 at 17 31 14" src="https://user-images.githubusercontent.com/105208209/221931726-617142d4-c0bf-4be1-bbfb-75d6ee6ccd1f.png">
<img width="424" alt="Screenshot 2023-02-28 at 17 31 20" src="https://user-images.githubusercontent.com/105208209/221931730-df273465-50a8-4bfb-8fa2-64f69482b8c6.png">



