### PR TITLE
test: add events testing framework

### DIFF
--- a/apps/wallet-mock/src/test/service.cy.ts
+++ b/apps/wallet-mock/src/test/service.cy.ts
@@ -1,0 +1,61 @@
+describe('Interactions', () => {
+  before(() => {
+    cy.visit('/')
+  })
+  it('should display unhealthy status', () => {
+    cy.visit('/')
+    cy.window().then((win) => {
+      win.document.body.dispatchEvent(new CustomEvent('service_is_unhealthy'))
+    })
+    cy.get('[data-testid="service-status-unhealthy"]').should(
+      'have.text',
+      'Wallet Service: Unhealthy Restart'
+    )
+  })
+
+  it('should display healthy status', () => {
+    cy.visit('/')
+    cy.window().then((win) => {
+      win.document.body.dispatchEvent(new CustomEvent('service_is_healthy'))
+    })
+    cy.get('[data-testid="service-status"]').should(
+      'have.text',
+      'Wallet Service: test on http://localhost:1789'
+    )
+  })
+
+  it('should display unreachable status', () => {
+    cy.visit('/')
+    cy.window().then((win) => {
+      win.document.body.dispatchEvent(new CustomEvent('service_unreachable'))
+    })
+    cy.get('[data-testid="service-status-unreachable"]').should(
+      'have.text',
+      'Wallet Service: Not reachable, retrying'
+    )
+  })
+
+  it('should display service stopped with error status', () => {
+    cy.visit('/')
+    cy.window().then((win) => {
+      win.document.body.dispatchEvent(
+        new CustomEvent('service_stopped_with_error')
+      )
+    })
+    cy.get('[data-testid="service-status-error"]').should(
+      'have.text',
+      'Wallet Service: Failed to start. Try to restart'
+    )
+  })
+
+  it('should display service stopped status', () => {
+    cy.visit('/')
+    cy.window().then((win) => {
+      win.document.body.dispatchEvent(new CustomEvent('service_stopped'))
+    })
+    cy.get('[data-testid="service-status-stopped"]').should(
+      'have.text',
+      'Wallet Service: Not running. Start service'
+    )
+  })
+})

--- a/libs/wallet-ui/src/__mocks__/service.ts
+++ b/libs/wallet-ui/src/__mocks__/service.ts
@@ -1,11 +1,17 @@
 import log from 'loglevel'
 import storageMock from './storage-mock'
 import type { Service } from '../types/service'
+import type { RawInteraction } from '../types'
 
 const logger = log.getLogger('test')
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
+
+type CallbackFunctionTypes =
+  | (() => void)
+  | ((interaction: RawInteraction) => void)
+  | ((err: Error) => void)
 
 export const service: Service = {
   TYPE: 'http',
@@ -76,7 +82,12 @@ export const service: Service = {
     }),
 
   // API
-  EventsOn: noop,
+  EventsOn: (event: string, cb: CallbackFunctionTypes) => {
+    window.document.body.addEventListener(event, (e) => {
+      const detail = e && (e as CustomEvent).detail
+      cb(detail)
+    })
+  },
   EventsOff: noop,
   RespondToInteraction: () => Promise.resolve(undefined),
 }

--- a/libs/wallet-ui/src/components/chrome/service-status.tsx
+++ b/libs/wallet-ui/src/components/chrome/service-status.tsx
@@ -95,7 +95,7 @@ export function ServiceStatus() {
     }
     case ServiceState.Stopped: {
       return (
-        <div data-testid="service-status" className="whitespace-nowrap">
+        <div data-testid="service-status-stopped" className="whitespace-nowrap">
           <StatusCircle background="bg-red" />
           <span>
             Wallet Service: Not running.{' '}
@@ -108,7 +108,7 @@ export function ServiceStatus() {
     }
     case ServiceState.Loading: {
       return (
-        <div data-testid="service-status" className="whitespace-nowrap">
+        <div data-testid="service-status-loading" className="whitespace-nowrap">
           <StatusCircle blinking background="bg-orange" />
           <span className="loading">Wallet Service: Loading</span>
         </div>
@@ -116,7 +116,10 @@ export function ServiceStatus() {
     }
     case ServiceState.Stopping: {
       return (
-        <div data-testid="service-status" className="whitespace-nowrap">
+        <div
+          data-testid="service-status-stopping"
+          className="whitespace-nowrap"
+        >
           <StatusCircle blinking background="bg-orange" />
           <span className="loading">Wallet Service: Stopping</span>
         </div>
@@ -124,7 +127,10 @@ export function ServiceStatus() {
     }
     case ServiceState.Unhealthy: {
       return (
-        <div data-testid="service-status" className="whitespace-nowrap">
+        <div
+          data-testid="service-status-unhealthy"
+          className="whitespace-nowrap"
+        >
           <StatusCircle blinking background="bg-orange" />
           <span>
             Wallet Service: Unhealthy{' '}
@@ -135,7 +141,10 @@ export function ServiceStatus() {
     }
     case ServiceState.Unreachable: {
       return (
-        <div data-testid="service-status" className="whitespace-nowrap">
+        <div
+          data-testid="service-status-unreachable"
+          className="whitespace-nowrap"
+        >
           <StatusCircle blinking background="bg-orange" />
           <span className="loading">
             Wallet Service: Not reachable, retrying
@@ -145,7 +154,7 @@ export function ServiceStatus() {
     }
     case ServiceState.Error: {
       return (
-        <div data-testid="service-status" className="whitespace-nowrap">
+        <div data-testid="service-status-error" className="whitespace-nowrap">
           <StatusCircle background="bg-red" />
           <span>
             Wallet Service: Failed to start.{' '}


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Create an event based mocking system for interaction testing.
Add tests for service status.

# Technical 👨‍🔧

Uses an event listener on the window object to allow the tests to have control of sending interactions via the window object. Using custom events we can use `detail` to specify custom data which comes from the backend.
