### PR TITLE
fix: transaction buttons not being disabled properly

### DIFF
--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",

--- a/libs/wallet-ui/src/components/interactions/flows/transaction-review/transaction-review.tsx
+++ b/libs/wallet-ui/src/components/interactions/flows/transaction-review/transaction-review.tsx
@@ -168,12 +168,12 @@ export const TransactionReview = ({
       {!isProcessing && (
         <TransactionDetails transaction={data.transaction} showStatus={false} />
       )}
-      {data.transaction.status === TransactionStatus.PENDING && (
+      {!isProcessing && data.transaction.status === TransactionStatus.PENDING && (
         <ButtonGroup inline>
           <Button
             data-testid="transaction-approve-button"
             loading={isLoading === 'approve'}
-            disabled={!!isLoading}
+            disabled={!!isLoading && !!isProcessing}
             onClick={() => handleDecision(true)}
           >
             Approve
@@ -181,7 +181,7 @@ export const TransactionReview = ({
           <Button
             data-testid="transaction-reject-button"
             loading={isLoading === 'reject'}
-            disabled={!!isLoading}
+            disabled={!!isLoading && !!isProcessing}
             onClick={() => handleDecision(false)}
           >
             Reject


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/623

# Description ℹ️

Approval and reject buttons were left non-disabled when the user had approved the tx. This PR prevents that.