### PR TITLE
fix: import button opens add network form

### DIFF
--- a/libs/wallet-ui/src/components/chrome/drawer-network.tsx
+++ b/libs/wallet-ui/src/components/chrome/drawer-network.tsx
@@ -31,10 +31,7 @@ export function DrawerNetwork({ setView }: DrawerNetworkProps) {
         </div>
       ) : (
         <div>
-          <Button
-            data-testid="import"
-            onClick={() => setView(DrawerPanel.Manage)}
-          >
+          <Button data-testid="import" onClick={() => setView(DrawerPanel.Add)}>
             Import
           </Button>
         </div>


### PR DESCRIPTION
# Related issues 🔗

Closes #180

# Description ℹ️

Import button opens add network form instead of manage networks view

# Demo 📺

https://user-images.githubusercontent.com/1980305/234213098-99820772-e1ce-4f0a-be0f-848c28421b35.mov

