### PR TITLE
chore: the big button swap

### DIFF
--- a/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-disconnect.tsx
@@ -65,10 +65,10 @@ export const Disconnect = ({
         </p>
       </div>
       <ButtonGroup inline className="p-5">
+        <ButtonUnstyled onClick={onClose}>Cancel</ButtonUnstyled>
         <Button loading={isLoading} onClick={handleDisconnect}>
           Disconnect
         </Button>
-        <ButtonUnstyled onClick={onClose}>Cancel</ButtonUnstyled>
       </ButtonGroup>
     </div>
   )

--- a/libs/wallet-ui/src/components/connection-list/connection-manage.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-manage.tsx
@@ -192,8 +192,8 @@ export const ManagePermissions = ({
         </div>
       </div>
       <ButtonGroup inline className="px-[20px] pb-[20px]">
-        <Button type="submit">Update</Button>
         <ButtonUnstyled onClick={onClose}>Cancel</ButtonUnstyled>
+        <Button type="submit">Update</Button>
       </ButtonGroup>
     </form>
   )

--- a/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
+++ b/libs/wallet-ui/src/components/connection-list/connection-remove.tsx
@@ -46,6 +46,12 @@ export const Remove = ({ wallet, hostname, onClose }: RemoveDialogProps) => {
         </p>
       </div>
       <ButtonGroup inline className="p-[20px]">
+        <ButtonUnstyled
+          data-testid="remove-connection-cancel-button"
+          onClick={onClose}
+        >
+          Cancel
+        </ButtonUnstyled>
         <Button
           data-testid="remove-connection-remove-button"
           loading={isLoading}
@@ -53,12 +59,6 @@ export const Remove = ({ wallet, hostname, onClose }: RemoveDialogProps) => {
         >
           Remove
         </Button>
-        <ButtonUnstyled
-          data-testid="remove-connection-cancel-button"
-          onClick={onClose}
-        >
-          Cancel
-        </ButtonUnstyled>
       </ButtonGroup>
     </div>
   )

--- a/libs/wallet-ui/src/components/interactions/flows/permission-request/permission-request.tsx
+++ b/libs/wallet-ui/src/components/interactions/flows/permission-request/permission-request.tsx
@@ -130,6 +130,15 @@ export const PermissionRequest = ({
       </Frame>
       <ButtonGroup inline>
         <Button
+          data-testid="wallet-request-permissions-reject"
+          // TODO loading spinner
+          // loading={isLoading === 'rejecßt'}
+          disabled={!!isLoading}
+          onClick={() => handleDecision(false)}
+        >
+          Cancel
+        </Button>
+        <Button
           data-testid="wallet-request-permissions-approve"
           // TODO loading spinner
           // loading={isLoading === 'approve'}
@@ -138,15 +147,6 @@ export const PermissionRequest = ({
           onClick={() => handleDecision(true)}
         >
           Approve
-        </Button>
-        <Button
-          data-testid="wallet-request-permissions-reject"
-          // TODO loading spinner
-          // loading={isLoading === 'rejecßt'}
-          disabled={!!isLoading}
-          onClick={() => handleDecision(false)}
-        >
-          Cancel
         </Button>
       </ButtonGroup>
     </div>

--- a/libs/wallet-ui/src/components/interactions/flows/transaction-review/transaction-review.tsx
+++ b/libs/wallet-ui/src/components/interactions/flows/transaction-review/transaction-review.tsx
@@ -195,20 +195,20 @@ export const TransactionReview = ({
       {!isProcessing && data.transaction.status === TransactionStatus.PENDING && (
         <ButtonGroup inline>
           <Button
-            data-testid="transaction-approve-button"
-            loading={isLoading === 'approve'}
-            disabled={!!isLoading && !!isProcessing}
-            onClick={() => handleDecision(true)}
-          >
-            Approve
-          </Button>
-          <Button
             data-testid="transaction-reject-button"
             loading={isLoading === 'reject'}
             disabled={!!isLoading && !!isProcessing}
             onClick={() => handleDecision(false)}
           >
             Reject
+          </Button>
+          <Button
+            data-testid="transaction-approve-button"
+            loading={isLoading === 'approve'}
+            disabled={!!isLoading && !!isProcessing}
+            onClick={() => handleDecision(true)}
+          >
+            Approve
           </Button>
         </ButtonGroup>
       )}

--- a/libs/wallet-ui/src/components/interactions/flows/wallet-connection/views/connection.tsx
+++ b/libs/wallet-ui/src/components/interactions/flows/wallet-connection/views/connection.tsx
@@ -65,6 +65,15 @@ export const ConnectionView = ({
       </Frame>
       <ButtonGroup inline>
         <Button
+          data-testid="dapp-connect-deny-button"
+          // TODO need a loading spinner but UI toolkit doesn't support this
+          // loading={isLoading === 'reject'}
+          disabled={!!isLoading}
+          onClick={() => handleDecision(false)}
+        >
+          Deny
+        </Button>
+        <Button
           data-testid="dapp-connect-approve-button"
           variant="primary"
           // TODO need a loading spinner but UI toolkit doesn't support this
@@ -73,15 +82,6 @@ export const ConnectionView = ({
           onClick={() => handleDecision(true)}
         >
           Approve
-        </Button>
-        <Button
-          data-testid="dapp-connect-deny-button"
-          // TODO need a loading spinner but UI toolkit doesn't support this
-          // loading={isLoading === 'reject'}
-          disabled={!!isLoading}
-          onClick={() => handleDecision(false)}
-        >
-          Deny
         </Button>
       </ButtonGroup>
     </div>

--- a/libs/wallet-ui/src/components/interactions/flows/wallet-connection/views/passphrase.tsx
+++ b/libs/wallet-ui/src/components/interactions/flows/wallet-connection/views/passphrase.tsx
@@ -121,6 +121,12 @@ export const PassphraseView = ({
           </FormGroup>
         </Frame>
         <ButtonGroup inline>
+          <ButtonLink
+            data-testid="dapp-passphrase-cancel-button"
+            onClick={() => onDeny()}
+          >
+            Cancel
+          </ButtonLink>
           <Button
             data-testid="dapp-passphrase-approve-button"
             variant="primary"
@@ -131,12 +137,6 @@ export const PassphraseView = ({
           >
             Approve
           </Button>
-          <ButtonLink
-            data-testid="dapp-passphrase-cancel-button"
-            onClick={() => onDeny()}
-          >
-            Cancel
-          </ButtonLink>
         </ButtonGroup>
       </form>
     </div>

--- a/libs/wallet-ui/src/components/interactions/flows/wallet-connection/views/selection.tsx
+++ b/libs/wallet-ui/src/components/interactions/flows/wallet-connection/views/selection.tsx
@@ -89,18 +89,18 @@ export const SelectionView = ({
         </Frame>
         <ButtonGroup inline>
           <Button
+            data-testid="dapp-select-deny-button"
+            onClick={() => onDeny()}
+          >
+            Deny
+          </Button>
+          <Button
             data-testid="dapp-select-approve-button"
             variant="primary"
             type="submit"
             disabled={isLoading || !formState.isValid}
           >
             Approve
-          </Button>
-          <Button
-            data-testid="dapp-select-deny-button"
-            onClick={() => onDeny()}
-          >
-            Deny
           </Button>
         </ButtonGroup>
       </form>

--- a/libs/wallet-ui/src/components/network-compatibility-dialog/choose-network.tsx
+++ b/libs/wallet-ui/src/components/network-compatibility-dialog/choose-network.tsx
@@ -48,8 +48,8 @@ export const ChangeNetwork = ({
         Add network
       </ButtonUnstyled>
       <ButtonGroup inline className="py-[20px]">
-        <Button type="submit">Select network</Button>
         <ButtonUnstyled onClick={onCancel}>Cancel</ButtonUnstyled>
+        <Button type="submit">Select network</Button>
       </ButtonGroup>
     </form>
   )

--- a/libs/wallet-ui/src/components/network-import-form/network-import-form.tsx
+++ b/libs/wallet-ui/src/components/network-import-form/network-import-form.tsx
@@ -126,6 +126,7 @@ export function NetworkImportForm({
         </FormGroup>
       )}
       <ButtonGroup inline>
+        {onCancel && <ButtonUnstyled onClick={onCancel}>Cancel</ButtonUnstyled>}
         <Button
           data-testid="import-network"
           type="submit"
@@ -133,7 +134,6 @@ export function NetworkImportForm({
         >
           Import
         </Button>
-        {onCancel && <ButtonUnstyled onClick={onCancel}>Cancel</ButtonUnstyled>}
       </ButtonGroup>
     </form>
   )

--- a/libs/wallet-ui/src/components/network-switcher/connections-warning-dialog.tsx
+++ b/libs/wallet-ui/src/components/network-switcher/connections-warning-dialog.tsx
@@ -52,8 +52,8 @@ export const ConnectionsWarningDialog = ({
         </p>
       </div>
       <ButtonGroup inline className="p-[20px]">
-        <Button onClick={onConfirm}>Switch</Button>
         <ButtonUnstyled onClick={() => setOpen(false)}>Cancel</ButtonUnstyled>
+        <Button onClick={onConfirm}>Switch</Button>
       </ButtonGroup>
     </Dialog>
   )

--- a/libs/wallet-ui/src/components/passphrase-modal/passphrase-modal.tsx
+++ b/libs/wallet-ui/src/components/passphrase-modal/passphrase-modal.tsx
@@ -108,11 +108,6 @@ function PassphraseModalForm({
       </FormGroup>
       <ButtonGroup inline>
         <div className="flex-1">
-          <Button data-testid="input-submit" type="submit" fill={true}>
-            {loading ? <Spinner /> : 'Submit'}
-          </Button>
-        </div>
-        <div className="flex-1">
           <button
             data-testid="input-cancel"
             onClick={onCancel}
@@ -121,6 +116,11 @@ function PassphraseModalForm({
           >
             Cancel
           </button>
+        </div>
+        <div className="flex-1">
+          <Button data-testid="input-submit" type="submit" fill={true}>
+            {loading ? <Spinner /> : 'Submit'}
+          </Button>
         </div>
       </ButtonGroup>
     </form>

--- a/libs/wallet-ui/src/components/remove-wallet/remove-wallet.tsx
+++ b/libs/wallet-ui/src/components/remove-wallet/remove-wallet.tsx
@@ -97,12 +97,12 @@ const RemoveForm = ({
         />
       </FormGroup>
       <ButtonGroup inline>
-        <Button type="submit" disabled={isPending}>
-          {isPending ? <Spinner /> : 'Remove'}
-        </Button>
         <button className="underline" onClick={onCancel}>
           Cancel
         </button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? <Spinner /> : 'Remove'}
+        </Button>
       </ButtonGroup>
     </form>
   )

--- a/libs/wallet-ui/src/components/sign-message-dialog/sign-message-dialog.tsx
+++ b/libs/wallet-ui/src/components/sign-message-dialog/sign-message-dialog.tsx
@@ -47,6 +47,14 @@ export const SignMessageDialog = () => {
               </CopyWithTooltip>
             </div>
             <ButtonGroup inline>
+              <ButtonUnstyled
+                data-testid="sign-close"
+                onClick={() =>
+                  dispatch({ type: 'SET_SIGN_MESSAGE_MODAL', open: false })
+                }
+              >
+                Close
+              </ButtonUnstyled>
               <Button
                 data-testid="sign-more"
                 onClick={() => {
@@ -56,14 +64,6 @@ export const SignMessageDialog = () => {
               >
                 Sign another
               </Button>
-              <ButtonUnstyled
-                data-testid="sign-close"
-                onClick={() =>
-                  dispatch({ type: 'SET_SIGN_MESSAGE_MODAL', open: false })
-                }
-              >
-                Close
-              </ButtonUnstyled>
             </ButtonGroup>
           </>
         ) : (
@@ -85,11 +85,6 @@ export const SignMessageDialog = () => {
             </FormGroup>
             <ButtonGroup inline>
               <div className="flex-1">
-                <Button data-testid="sign" type="submit" fill={true}>
-                  Sign
-                </Button>
-              </div>
-              <div className="flex-1">
                 <button
                   data-testid="sign-close"
                   onClick={() =>
@@ -99,6 +94,11 @@ export const SignMessageDialog = () => {
                 >
                   Cancel
                 </button>
+              </div>
+              <div className="flex-1">
+                <Button data-testid="sign" type="submit" fill={true}>
+                  Sign
+                </Button>
               </div>
             </ButtonGroup>
           </form>

--- a/libs/wallet-ui/src/components/taint-key-dialog/taint-key-dialog.tsx
+++ b/libs/wallet-ui/src/components/taint-key-dialog/taint-key-dialog.tsx
@@ -53,6 +53,14 @@ export const TaintKeyDialog = () => {
       <PublicKey publicKey={keypair.publicKey} />
       <div className="pt-[32px] px-[20px] pb-[20px]">
         <ButtonGroup inline>
+          <button
+            onClick={() =>
+              dispatch({ type: 'SET_TAINT_KEY_MODAL', open: false })
+            }
+            className="underline w-full"
+          >
+            Cancel
+          </button>
           <Button
             data-testid="taint-action"
             disabled={loading}
@@ -68,14 +76,6 @@ export const TaintKeyDialog = () => {
           >
             {keypair.isTainted ? 'Untaint this key' : 'Taint this key'}
           </Button>
-          <button
-            onClick={() =>
-              dispatch({ type: 'SET_TAINT_KEY_MODAL', open: false })
-            }
-            className="underline w-full"
-          >
-            Cancel
-          </button>
         </ButtonGroup>
       </div>
     </Dialog>

--- a/libs/wallet-ui/src/components/update-keypair-dialog/update-keypair-dialog.tsx
+++ b/libs/wallet-ui/src/components/update-keypair-dialog/update-keypair-dialog.tsx
@@ -236,16 +236,6 @@ function UpdateKeyForm({ keypair, wallet }: UpdateKeyFormProps) {
       </div>
       <ButtonGroup>
         <div className="flex-1">
-          <Button
-            data-testid="metadata-submit"
-            disabled={loading}
-            type="submit"
-            fill={true}
-          >
-            Update
-          </Button>
-        </div>
-        <div className="flex-1">
           <button
             onClick={() =>
               dispatch({ type: 'SET_UPDATE_KEY_MODAL', open: false })
@@ -254,6 +244,16 @@ function UpdateKeyForm({ keypair, wallet }: UpdateKeyFormProps) {
           >
             Cancel
           </button>
+        </div>
+        <div className="flex-1">
+          <Button
+            data-testid="metadata-submit"
+            disabled={loading}
+            type="submit"
+            fill={true}
+          >
+            Update
+          </Button>
         </div>
       </ButtonGroup>
     </form>

--- a/libs/wallet-ui/src/components/wallet-create-form/wallet-create-form.tsx
+++ b/libs/wallet-ui/src/components/wallet-create-form/wallet-create-form.tsx
@@ -78,6 +78,11 @@ export function WalletCreateForm({ submit, cancel }: WalletCreateFormProps) {
       </FormGroup>
       <ButtonGroup inline>
         <div className="flex-1">
+          <button className="underline w-full" onClick={cancel}>
+            Cancel
+          </button>
+        </div>
+        <div className="flex-1">
           <Button
             data-testid="create-wallet-form-submit"
             type="submit"
@@ -85,11 +90,6 @@ export function WalletCreateForm({ submit, cancel }: WalletCreateFormProps) {
           >
             Submit
           </Button>
-        </div>
-        <div className="flex-1">
-          <button className="underline w-full" onClick={cancel}>
-            Cancel
-          </button>
         </div>
       </ButtonGroup>
     </form>

--- a/libs/wallet-ui/src/components/wallet-edit/wallet-edit.tsx
+++ b/libs/wallet-ui/src/components/wallet-edit/wallet-edit.tsx
@@ -61,8 +61,8 @@ export const WalletEdit = ({ onClose }: WalletEditProps) => {
         />
       </FormGroup>
       <ButtonGroup inline>
-        <Button type="submit">Update</Button>
         <ButtonUnstyled onClick={onClose}>Cancel</ButtonUnstyled>
+        <Button type="submit">Update</Button>
       </ButtonGroup>
     </form>
   )

--- a/libs/wallet-ui/src/components/wallet-import-form/wallet-import-form.tsx
+++ b/libs/wallet-ui/src/components/wallet-import-form/wallet-import-form.tsx
@@ -112,15 +112,6 @@ export function WalletImportForm({ submit, cancel }: WalletImportFormProps) {
       </FormGroup>
       <ButtonGroup inline>
         <div className="flex-1">
-          <Button
-            data-testid="wallet-import-form-submit"
-            type="submit"
-            fill={true}
-          >
-            Submit
-          </Button>
-        </div>
-        <div className="flex-1">
           <button
             data-testid="cancel"
             onClick={cancel}
@@ -128,6 +119,15 @@ export function WalletImportForm({ submit, cancel }: WalletImportFormProps) {
           >
             Cancel
           </button>
+        </div>
+        <div className="flex-1">
+          <Button
+            data-testid="wallet-import-form-submit"
+            type="submit"
+            fill={true}
+          >
+            Submit
+          </Button>
         </div>
       </ButtonGroup>
     </form>


### PR DESCRIPTION
# Related issues 🔗

Closes #148 

# Description ℹ️

As per the ticket, went through the actions in the app, and made sure negative actions (close, cancel, etc) are lined up on the left side horizontally.

# Demo 📺

A few example screenshots of some of the resulting displays:


<img width="443" alt="Screenshot 2023-05-01 at 11 15 04" src="https://user-images.githubusercontent.com/105208209/235443904-fdd50b38-8618-4742-bec6-063e42f1c041.png">
<img width="955" alt="Screenshot 2023-05-01 at 12 15 35" src="https://user-images.githubusercontent.com/105208209/235444722-a086832f-54b6-49f7-b259-c5c47d1b1588.png">
<img width="950" alt="Screenshot 2023-05-01 at 12 15 18" src="https://user-images.githubusercontent.com/105208209/235444724-996ef627-a486-4bb8-841f-533d33d8561e.png">
<img width="949" alt="Screenshot 2023-05-01 at 12 15 06" src="https://user-images.githubusercontent.com/105208209/235444725-99cc77e8-bde2-4139-b33e-9299c63f5879.png">
<img width="948" alt="Screenshot 2023-05-01 at 12 14 53" src="https://user-images.githubusercontent.com/105208209/235444726-096a46c3-b225-4807-8a04-0c71a861876a.png">
<img width="949" alt="Screenshot 2023-05-01 at 12 14 43" src="https://user-images.githubusercontent.com/105208209/235444728-95a6ba20-514f-4a31-abf4-8d8822a9b4cf.png">
<img width="952" alt="Screenshot 2023-05-01 at 12 14 31" src="https://user-images.githubusercontent.com/105208209/235444729-b362214d-fe9f-43e9-8be3-774d78ae9455.png">

