### PR TITLE
fix: tx logs copy content

### DIFF
--- a/libs/wallet-ui/src/components/transaction-logs/transaction-logs.tsx
+++ b/libs/wallet-ui/src/components/transaction-logs/transaction-logs.tsx
@@ -10,7 +10,7 @@ export const TransactionLogs = ({ logs }: Props) => {
   return (
     <div style={{ maxWidth: 500 }}>
       <CodeWindow
-        text={logs.join('\n')}
+        text={logs.map((l) => l.message).join('\n')}
         content={logs.map((entry, i) => (
           <p
             key={i}


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/vegawallet-desktop/issues/679

(the other part of the ticket with the BE links has been fixed here: https://github.com/vegaprotocol/networks-internal/pull/247)

# Description ℹ️

Fix transaction logs content not being copied correctly.