### PR TITLE
fix: back on transactions in wallet

### DIFF
--- a/libs/wallet-ui/src/routes/wallet/keypair/transactions.tsx
+++ b/libs/wallet-ui/src/routes/wallet/keypair/transactions.tsx
@@ -24,7 +24,7 @@ export function Transactions() {
   return (
     <Page
       name="Transactions"
-      back={`${Paths.Wallet.Wallet(':wallet')}/keypair/${keypair.publicKey}`}
+      back={`${Paths.Wallet.Wallet(wallet)}/keypair/${keypair.publicKey}`}
     >
       <>
         <PublicKey publicKey={keypair.publicKey} />


### PR DESCRIPTION
# Related issues 🔗

Back button on keypair/transactions was going back to the home page, this was due to a hardcoded wallet name which has now been made dynamic
