### PR TITLE
fix: unlock wallet when importing / creating in the app

### DIFF
--- a/libs/wallet-ui/src/contexts/global/global-reducer.ts
+++ b/libs/wallet-ui/src/contexts/global/global-reducer.ts
@@ -119,6 +119,7 @@ export type GlobalAction =
   | {
       type: 'ADD_WALLET'
       wallet: string
+      auth?: boolean
       key: WalletModel.DescribeKeyResult
     }
   | {
@@ -357,7 +358,7 @@ export function globalReducer(
             [keypairExtended.publicKey ?? '']: keypairExtended,
           }),
         },
-        auth: false,
+        auth: action.auth || false,
       }
       return {
         ...state,

--- a/libs/wallet-ui/src/hooks/use-create-wallet.tsx
+++ b/libs/wallet-ui/src/hooks/use-create-wallet.tsx
@@ -51,6 +51,7 @@ export function useCreateWallet() {
             type: 'ADD_WALLET',
             wallet: values.wallet,
             key: keypair,
+            auth: true,
           })
           dispatch({
             type: 'ACTIVATE_WALLET',

--- a/libs/wallet-ui/src/hooks/use-create-wallet.tsx
+++ b/libs/wallet-ui/src/hooks/use-create-wallet.tsx
@@ -53,10 +53,6 @@ export function useCreateWallet() {
             key: keypair,
             auth: true,
           })
-          dispatch({
-            type: 'ACTIVATE_WALLET',
-            wallet: values.wallet,
-          })
         } else {
           AppToaster.show({ message: 'Error: Unknown', intent: Intent.DANGER })
         }

--- a/libs/wallet-ui/src/hooks/use-import-wallet.tsx
+++ b/libs/wallet-ui/src/hooks/use-import-wallet.tsx
@@ -56,6 +56,7 @@ export function useImportWallet() {
             type: 'ADD_WALLET',
             wallet: values.wallet,
             key: keypair,
+            auth: true,
           })
           AppToaster.show({
             message: `Wallet imported`,


### PR DESCRIPTION
# Related issues 🔗

Closes n/a

# Description ℹ️

Have the freshly imported / created wallets unlocked by default, as the app doesn't require a passphrase for them.
