### PR TITLE
chore: update wallet-ui version to test dependandbot

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -29,7 +29,7 @@ jobs:
           yarn playwright install-deps chromium
 
       - name: Run tests
-        run: yarn e2e:percy
+        run: yarn e2e
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 

--- a/libs/wallet-ui/package.json
+++ b/libs/wallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vegaprotocol/wallet-ui",
   "author": "Gobalsky Labs Ltd.",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "license": "MIT",
   "types": "./index.d.ts",
   "homepage": "https://github.com/vegaprotocol/vegawallet-ui/tree/develop/libs/wallet-ui",


### PR DESCRIPTION
We have some problems with dependandbot in `vegawallet-desktop` repo, so we need to debug it with new version.